### PR TITLE
Json Diffs Handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['adopt@1.8', 'adopt@1.11']
+        java: ['adopt@1.11', 'adopt@1.17']
         scala: ['2.13.10', '3.2.2']
     steps:
       - name: Checkout current branch
@@ -57,7 +57,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      
+
       - run: ./mill -i -k __.publishLocal $(pwd)/testRepo
 
       - name: Run tests
@@ -71,7 +71,7 @@ jobs:
       # when in master repo: all commits to main branch and all additional tags
     if: github.repository == 'finos/morphir-scala' && ( github.ref == 'refs/heads/main' || (github.ref != 'refs/heads/main' && startsWith( github.ref, 'refs/tags/') ) )
     needs: [ci]
-    
+
     runs-on: ubuntu-latest
 
     # only run one publish job for the same sha at the same time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['adopt@1.11', 'adopt@1.17']
+        java: ['adopt@1.11', 'adopt@1.16']
         scala: ['2.13.10', '3.2.2']
     steps:
       - name: Checkout current branch

--- a/build.sc
+++ b/build.sc
@@ -281,7 +281,13 @@ object morphir extends Module {
               morphir.testing(crossScalaVersion).jvm,
               morphir.toolkit.core.testing(crossScalaVersion)
             )
-            def ivyDeps = T(super.ivyDeps() ++ Agg(dev.zio.`zio-json-golden`))
+            def ivyDeps = T(
+              super.ivyDeps() ++ Agg(
+                dev.zio.`zio-json-golden`,
+                ivy"io.github.deblockt:json-diff:0.0.5",
+                dev.zio.`zio-process`
+              )
+            )
           }
         }
       }

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonDecodingSpec.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonDecodingSpec.scala
@@ -22,7 +22,8 @@ import org.finos.morphir.ir.Type.{Definition => TypeDefinition, Specification =>
 import org.finos.morphir.ir.Value.{Definition => ValueDefinition, Pattern, Specification => ValueSpecification, Value}
 import org.finos.morphir.ir._
 import org.finos.morphir.ir.json.MorphirJsonSupport._
-import zio.test.*
+import org.finos.morphir.ir.json.util.CustomAssert._
+import zio.test._
 
 object MorphirJsonDecodingSpec extends ZIOSpecDefault {
   def spec = suite("Json Decoding Suite")(
@@ -30,201 +31,201 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
       test("will decode a Unit") {
         val actual   = """[]"""
         val expected = ()
-        assertTrue(actual.fromJson[scala.Unit] == Right(expected))
+        assert(actual.fromJson[scala.Unit])(objectEqualTo(Right(expected)))
       },
       test("will not decode a Unit") {
         val actual   = """["hello", "there"]"""
         val expected = Left("(Expected empty list, got [hello, there])")
-        assertTrue(actual.fromJson[scala.Unit] == expected)
+        assert(actual.fromJson[scala.Unit])(objectEqualTo(expected))
       }
     ),
     suite("Name")(
       test("will decode an empty Name") {
         val actual   = "[]"
         val expected = Name.empty
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       },
       test("will decode a single Name") {
         val actual   = """["hello"]"""
         val expected = Name("Hello")
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       },
       test("will decode a Name") {
         val actual   = """["hello","there"]"""
         val expected = Name("HelloThere")
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       },
       test("will decode a Name fromString") {
         val actual   = """["hello","there"]"""
         val expected = Name.fromString("Hello.There")
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       },
       test("will decode a Name fromList") {
         val actual   = """["this","is","a","list"]"""
         val expected = Name.fromList(List("This", "is", "a", "list"))
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Path")(
       test("will decode an empty Path") {
         val actual   = "[]"
         val expected = Path.empty
-        assertTrue(actual.fromJson[Path] == Right(expected))
+        assert(actual.fromJson[Path])(objectEqualTo(Right(expected)))
       },
       test("will decode a simple Path") {
         val actual   = """[["org"]]"""
         val expected = Path.fromString("org")
-        assertTrue(actual.fromJson[Path] == Right(expected))
+        assert(actual.fromJson[Path])(objectEqualTo(Right(expected)))
       },
       test("will decode a Path") {
         val actual   = """[["org"],["foo"],["bar"]]"""
         val expected = Path.fromString("org.foo.bar")
-        assertTrue(actual.fromJson[Path] == Right(expected))
+        assert(actual.fromJson[Path])(objectEqualTo(Right(expected)))
       }
     ),
     suite("ModulePath")(
       test("will decode an empty ModulePath") {
         val actual   = "[]"
         val expected = ModuleName(Path.empty)
-        assertTrue(actual.fromJson[ModuleName] == Right(expected))
+        assert(actual.fromJson[ModuleName])(objectEqualTo(Right(expected)))
       },
       test("will decode a simple ModulePath") {
         val actual   = """[["org"]]"""
         val expected = ModuleName(Path.fromString("org"))
-        assertTrue(actual.fromJson[ModuleName] == Right(expected))
+        assert(actual.fromJson[ModuleName])(objectEqualTo(Right(expected)))
       },
       test("will decode a ModulePath") {
         val actual   = """[["org"],["foo"],["bar"]]"""
         val expected = ModuleName(Path.fromString("org.foo.bar"))
-        assertTrue(actual.fromJson[ModuleName] == Right(expected))
+        assert(actual.fromJson[ModuleName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("PackageName")(
       test("will decode an empty PackageName") {
         val actual   = "[]"
         val expected = PackageName(Path.empty)
-        assertTrue(actual.fromJson[PackageName] == Right(expected))
+        assert(actual.fromJson[PackageName])(objectEqualTo(Right(expected)))
       },
       test("will decode a simple PackageName") {
         val actual   = """[["org"]]"""
         val expected = PackageName(Path.fromString("org"))
-        assertTrue(actual.fromJson[PackageName] == Right(expected))
+        assert(actual.fromJson[PackageName])(objectEqualTo(Right(expected)))
       },
       test("will decode a PackageName") {
         val actual   = """[["org"],["foo"],["bar"]]"""
         val expected = PackageName(Path.fromString("org.foo.bar"))
-        assertTrue(actual.fromJson[PackageName] == Right(expected))
+        assert(actual.fromJson[PackageName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("ModuleName")(
       test("will decode an empty ModuleName") {
         val actual   = "[[],[]]"
         val expected = QualifiedModuleName(Path.empty, Name.empty)
-        assertTrue(actual.fromJson[QualifiedModuleName] == Right(expected))
+        assert(actual.fromJson[QualifiedModuleName])(objectEqualTo(Right(expected)))
       },
       test("will decode a simple ModuleName") {
         val actual   = """[[["org"]],["src","test"]]"""
         val expected = QualifiedModuleName(Path.fromString("org"), Name.fromString("SrcTest"))
-        assertTrue(actual.fromJson[QualifiedModuleName] == Right(expected))
+        assert(actual.fromJson[QualifiedModuleName])(objectEqualTo(Right(expected)))
       },
       test("will decode a ModuleName") {
         val actual   = """[[["src"],["test"],["scala"]],["src","test"]]"""
         val expected = QualifiedModuleName(Path.fromString("src.test.scala"), Name.fromString("SrcTest"))
-        assertTrue(actual.fromJson[QualifiedModuleName] == Right(expected))
+        assert(actual.fromJson[QualifiedModuleName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("QName")(
       test("will decode an empty QName") {
         val actual   = "[[],[]]"
         val expected = QName(Path.empty, Name.empty)
-        assertTrue(actual.fromJson[QName] == Right(expected))
+        assert(actual.fromJson[QName])(objectEqualTo(Right(expected)))
       },
       test("will decode a QName") {
         val actual   = """[[["proper"],["path"]],["name"]]"""
         val expected = QName.fromString("Proper.Path:name").get
-        assertTrue(actual.fromJson[QName] == Right(expected))
+        assert(actual.fromJson[QName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("FQName")(
       test("will decode an empty FQName") {
         val actual   = "[[],[],[]]"
         val expected = FQName(Path.empty, Path.empty, Name.empty)
-        assertTrue(actual.fromJson[FQName] == Right(expected))
+        assert(actual.fromJson[FQName])(objectEqualTo(Right(expected)))
       },
       test("will decode a FQName") {
         val actual   = """[[["com"],["example"]],[["java","home"]],["morphir"]]"""
         val expected = FQName.fromString("Com.Example;JavaHome;morphir", ";")
-        assertTrue(actual.fromJson[FQName] == Right(expected))
+        assert(actual.fromJson[FQName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Documented")(
       test("will decode Documented for Integer") {
         val actual   = """{"doc":"This is an Integer 10","value":10}"""
         val expected = Documented("This is an Integer 10", 10)
-        assertTrue(actual.fromJson[Documented[Int]] == Right(expected))
+        assert(actual.fromJson[Documented[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Documented for String") {
         val actual   = """{"doc":"This is a String","value":"Hello"}"""
         val expected = Documented("This is a String", "Hello")
-        assertTrue(actual.fromJson[Documented[String]] == Right(expected))
+        assert(actual.fromJson[Documented[String]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("AccessControlled")(
       test("will decode AccessControlled for private Integer") {
         val actual   = """{"access":"Private","value":10}"""
         val expected = AccessControlled(AccessControlled.Access.Private, 10)
-        assertTrue(actual.fromJson[AccessControlled[Int]] == Right(expected))
+        assert(actual.fromJson[AccessControlled[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode AccessControlled for public String") {
         val actual   = """{"access":"Public","value":"Hello"}"""
         val expected = AccessControlled(AccessControlled.Access.Public, "Hello")
-        assertTrue(actual.fromJson[AccessControlled[String]] == Right(expected))
+        assert(actual.fromJson[AccessControlled[String]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Field")(
       test("will decode Field for private Integer") {
         val actual   = """{"name":["name"],"tpe":{"access":"Private","value":10}}"""
         val expected = Field(Name.fromString("Name"), AccessControlled(AccessControlled.Access.Private, 10))
-        assertTrue(actual.fromJson[Field[AccessControlled[Int]]] == Right(expected))
+        assert(actual.fromJson[Field[AccessControlled[Int]]])(objectEqualTo(Right(expected)))
       },
       test("will decode Field for public String") {
         val actual = """{"name":["string"],"tpe":{"access":"Public","value":"Hello"}}"""
         val expected =
           Field(Name.fromString("String"), AccessControlled(AccessControlled.Access.Public, "Hello"))
-        assertTrue(actual.fromJson[Field[AccessControlled[String]]] == Right(expected))
+        assert(actual.fromJson[Field[AccessControlled[String]]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Literal")(
       test("will decode a BoolLiteral") {
         val actual   = """["BoolLiteral",true]"""
         val expected = BoolLiteral(true)
-        assertTrue(actual.fromJson[BoolLiteral] == Right(expected))
+        assert(actual.fromJson[BoolLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode a CharLiteral") {
         val actual   = """["CharLiteral","x"]"""
         val expected = CharLiteral('x')
-        assertTrue(actual.fromJson[CharLiteral] == Right(expected))
+        assert(actual.fromJson[CharLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode a DecimalLiteral") {
         val actual   = """["DecimalLiteral","1.23456789"]"""
         val expected = DecimalLiteral(new java.math.BigDecimal("1.23456789"))
-        assertTrue(actual.fromJson[DecimalLiteral] == Right(expected))
+        assert(actual.fromJson[DecimalLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode a FloatLiteral") {
         val actual   = """["FloatLiteral",1.3232]"""
         val expected = FloatLiteral(1.3232d)
 
-        assertTrue(actual.fromJson[FloatLiteral] == Right(expected))
+        assert(actual.fromJson[FloatLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode a StringLiteral") {
         val actual   = """["StringLiteral","hello"]"""
         val expected = StringLiteral("hello")
-        assertTrue(actual.fromJson[StringLiteral] == Right(expected))
+        assert(actual.fromJson[StringLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode an WholeNumberLiteral") {
         val actual   = """["WholeNumberLiteral",321321]"""
         val expected = WholeNumberLiteral(321321L)
-        assertTrue(actual.fromJson[WholeNumberLiteral] == Right(expected))
+        assert(actual.fromJson[WholeNumberLiteral])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Type")(
@@ -296,14 +297,14 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
       test("will decode empty Constructor") {
         val actual   = """[]"""
         val expected = org.finos.morphir.ir.Type.Constructors[Int](Map.empty)
-        assertTrue(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]] == Right(expected))
+        assert(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Constructors with one constructor") {
         val name   = Name.fromString("name")
         val actual = """[[["name"],[[["name"],["Variable",123,["f"]]]]]]"""
         val expected =
           org.finos.morphir.ir.Type.Constructors[Int](Map((name, zio.Chunk((name, variable[Int](123, "f"))))))
-        assertTrue(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]] == Right(expected))
+        assert(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Constructors") {
         val name1 = Name.fromString("name1")
@@ -318,7 +319,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
             (name2, zio.Chunk((name3, variable[Int](678, "h")), (name4, variable[Int](789, "i"))))
           )
         )
-        assertTrue(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]] == Right(expected))
+        assert(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("TypeDefinition")(
@@ -408,7 +409,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
           """{"inputTypes":[[["name","1"],1,["Variable",345,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",345,["g"]],"body":["unit",1]}"""
         val expected =
           ValueDefinition[Int, Int](inputParams, variable[Int](345, "g"), Value.Unit(1))
-        assertTrue(actual.fromJson[ValueDefinition[Int, Int]] == Right(expected))
+        assert(actual.fromJson[ValueDefinition[Int, Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("ValueSpecification")(
@@ -420,7 +421,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val actual =
           """{"inputs":[[["name","1"],["Variable",345,["g"]]],[["name","2"],["Variable",678,["h"]]]],"outputs":["Variable",111,["f"]]}"""
         val expected = ValueSpecification[Int](inputs, variable[Int](111, "f"))
-        assertTrue(actual.fromJson[ValueSpecification[Int]] == Right(expected))
+        assert(actual.fromJson[ValueSpecification[Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Pattern")(
@@ -457,7 +458,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
       test("will decode LiteralPattern") {
         val actual   = """["literal_pattern",1,["StringLiteral","hello"]]"""
         val expected = Pattern.LiteralPattern[Int](1, StringLiteral("hello"))
-        assertTrue(actual.fromJson[Pattern.LiteralPattern[Int]] == Right(expected))
+        assert(actual.fromJson[Pattern.LiteralPattern[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode HeadTailPattern") {
         val actual = """["head_tail_pattern",1,["wildcard_pattern",1],["empty_list_pattern",2]]"""
@@ -518,7 +519,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val actual =
           """{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Variable",345,["g"]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Variable",345,["g"]]],[["name","2"],["Variable",678,["h"]]]],"outputs":["Variable",111,["f"]]}}]]}"""
         val expected = ModuleSpecification[Int](typeMap, valueMap)
-        assertTrue(actual.fromJson[ModuleSpecification[Int]] == Right(expected))
+        assert(actual.fromJson[ModuleSpecification[Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("PackageSpecification")(
@@ -543,7 +544,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val expected = PackageSpecification[Int](Map(modName1 -> modSpec, modName2 -> modSpec))
         val actual =
           """{"modules":[[[[["org"]],["src"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Variable",345,["g"]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Variable",345,["g"]]],[["name","2"],["Variable",678,["h"]]]],"outputs":["Variable",111,["f"]]}}]]}],[[[["org"]],["test"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Variable",345,["g"]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Variable",345,["g"]]],[["name","2"],["Variable",678,["h"]]]],"outputs":["Variable",111,["f"]]}}]]}]]}"""
-        assertTrue(actual.fromJson[PackageSpecification[Int]] == Right(expected))
+        assert(actual.fromJson[PackageSpecification[Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("ModuleDefinition")(
@@ -574,7 +575,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val expected = ModuleDefinition[Int, Int](typeMap, valueMap)
         val actual =
           """{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Variable",345,["g"]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],1,["Variable",345,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",345,["g"]],"body":["constructor",1,[[["test"]],[["java","home"]],["morphir"]]]}}}]]}"""
-        assertTrue(actual.fromJson[ModuleDefinition[Int, Int]] == Right(expected))
+        assert(actual.fromJson[ModuleDefinition[Int, Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("PackageDefinition")(
@@ -615,7 +616,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
           )
         )
 
-        assertTrue(actual.fromJson[PackageDefinition[Int, Int]] == Right(expected))
+        assert(actual.fromJson[PackageDefinition[Int, Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Value")(
@@ -623,46 +624,46 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val unitCase = Value.Unit(6)
         val actual   = """["apply",3,["unit",6],["unit",6]]"""
         val expected = Value.Apply(3, unitCase, unitCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - ConstructorCase") {
         val name     = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val actual   = """["constructor",3,[[["com"],["example"]],[["java","home"]],["morphir"]]]"""
         val expected = Value.Constructor(3, name)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - DestructureCase") {
         val pattern  = Pattern.WildcardPattern[Int](1)
         val unitCase = Value.Unit(6)
         val actual   = """["destructure",3,["wildcard_pattern",1],["unit",6],["unit",6]]"""
         val expected = Value.Destructure(3, pattern, unitCase, unitCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - FieldCase") {
         val name     = Name("Hello")
         val unitCase = Value.Unit(6)
         val actual   = """["field",3,["unit",6],["hello"]]"""
         val expected = Value.Field(3, unitCase, name)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - FieldFunctionCase") {
         val actual   = """["field_function",3,["hello"]]"""
         val expected = Value.FieldFunction(3, Name("Hello"))
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - IfThenElseCase") {
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val unitCase          = Value.Unit(6)
         val actual            = """["if_then_else",3,["unit",6],["field_function",3,["hello"]],["unit",6]]"""
         val expected          = Value.IfThenElse(3, unitCase, fieldFunctionCase, unitCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - LambdaCase") {
         val pattern           = Pattern.WildcardPattern[Int](1)
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val actual            = """["lambda",3,["wildcard_pattern",1],["field_function",3,["hello"]]]"""
         val expected          = Value.Lambda(3, pattern, fieldFunctionCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - LetDefinitionCase") {
         val inputParams = zio.Chunk(
@@ -678,7 +679,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
           """["let_definition",3,["hi"],{"inputTypes":[[["name","1"],1,["Variable",444,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",345,["g"]],"body":["literal",3,["BoolLiteral",true]]},["field_function",3,["hello"]]]"""
         val expected =
           Value.LetDefinition(3, Name("Hi"), valueDefinition, fieldFunctionCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - LetRecursionCase") {
         val inputParams = zio.Chunk(
@@ -695,20 +696,20 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val actual =
           """["let_recursion",3,[[["key","1"],{"inputTypes":[[["name","1"],1,["Variable",444,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",333,["x"]],"body":["literal",3,["BoolLiteral",true]]}],[["key","2"],{"inputTypes":[[["name","1"],1,["Variable",444,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",333,["x"]],"body":["literal",3,["BoolLiteral",true]]}]],["field_function",3,["hello"]]]"""
         val expected = Value.LetRecursion(3, valueDefinitions, fieldFunctionCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - ListCase") {
         val unitCase          = Value.Unit(6)
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val actual            = """["list",3,[["unit",6],["field_function",3,["hello"]]]]"""
         val expected          = Value.List(3, zio.Chunk[Value[Int, Int]](unitCase, fieldFunctionCase))
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - LiteralCase") {
         val literal  = BoolLiteral(true)
         val actual   = """["literal",3,["BoolLiteral",true]]"""
         val expected = Value.Literal(3, literal)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - PatternMatchCase") {
         val unitCase          = Value.Unit(6)
@@ -716,7 +717,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val patterns          = zio.Chunk((Pattern.WildcardPattern[Int](12), fieldFunctionCase))
         val actual   = """["pattern_match",3,["unit",6],[[["wildcard_pattern",12],["field_function",3,["hello"]]]]]"""
         val expected = Value.PatternMatch(3, unitCase, patterns)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - RecordCase") {
         val unitCase          = Value.Unit(6)
@@ -724,13 +725,13 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val fields            = zio.Chunk((Name("hello"), fieldFunctionCase), (Name("there"), unitCase))
         val actual            = """["record",3,[[["hello"],["field_function",3,["hello"]]],[["there"],["unit",6]]]]"""
         val expected          = Value.Record(3, fields)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - ReferenceCase") {
         val name     = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val actual   = """["reference",3,[[["com"],["example"]],[["java","home"]],["morphir"]]]"""
         val expected = Value.Reference(3, name)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - TupleCase") {
         val unitCase          = Value.Unit(6)
@@ -738,7 +739,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val elements          = zio.Chunk(unitCase, fieldFunctionCase)
         val actual            = """["tuple",3,[["unit",6],["field_function",3,["hello"]]]]"""
         val expected          = Value.Tuple(3, elements)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - UpdateRecordCase") {
         val unitCase          = Value.Unit(6)
@@ -747,17 +748,17 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val actual =
           """["update_record",3,["unit",6],[[["hello"],["field_function",3,["hello"]]],[["there"],["unit",6]]]]"""
         val expected = Value.UpdateRecord(3, unitCase, fields)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - UnitCase") {
         val actual   = """["unit",6]"""
         val expected = Value.Unit(6)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - VariableCase") {
         val actual   = """["variable",3,["hello"]]"""
         val expected = Value.Variable(3, Name("hello"))
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Distribution")(
@@ -814,10 +815,9 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val expected = Library(packageName, dependencies, packageDef)
         val actual =
           """["Library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[[[[["org"]],["src"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}],[[[["org"]],["test"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}]]}]],{"modules":[[[[["org"]],["src"]],{"access":"Public","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}],[[[["org"]],["test"]],{"access":"Private","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}]]}]"""
-        assertTrue(
-          actual.fromJson[Library] == Right(expected),
-          actual.fromJson[Distribution] == Right(expected)
-        )
+        assert(actual.fromJson[Library])(objectEqualTo(Right(expected))) &&
+        assert(actual.fromJson[Distribution])(objectEqualTo(Right(expected)))
+
       }
     ),
     suite("MorphirIRFile")(
@@ -874,9 +874,7 @@ object MorphirJsonDecodingSpec extends ZIOSpecDefault {
         val expected = MorphirIRFile(MorphirIRVersion.V2_0, Library(packageName, dependencies, packageDef))
         val actual =
           """{"formatVersion":2,"distribution":["Library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[[[[["org"]],["src"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}],[[[["org"]],["test"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}]]}]],{"modules":[[[[["org"]],["src"]],{"access":"Public","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}],[[[["org"]],["test"]],{"access":"Private","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}]]}]}"""
-        assertTrue(
-          actual.fromJson[MorphirIRFile] == Right(expected)
-        )
+        assert(actual.fromJson[MorphirIRFile])(objectEqualTo(Right(expected)))
       }
     )
   )

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonDecodingSpecV1.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonDecodingSpecV1.scala
@@ -22,7 +22,8 @@ import org.finos.morphir.ir.Type.{Definition => TypeDefinition, Specification =>
 import org.finos.morphir.ir.Value.{Definition => ValueDefinition, Pattern, Specification => ValueSpecification, Value}
 import org.finos.morphir.ir._
 import org.finos.morphir.ir.json.MorphirJsonSupportV1._
-import zio.test.*
+import org.finos.morphir.ir.json.util.CustomAssert._
+import zio.test._
 
 object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
   def spec = suite("Json Decoding Suite - V1")(
@@ -30,201 +31,201 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
       test("will decode a Unit") {
         val actual   = """[]"""
         val expected = ()
-        assertTrue(actual.fromJson[scala.Unit] == Right(expected))
+        assert(actual.fromJson[scala.Unit])(objectEqualTo(Right(expected)))
       },
       test("will not decode a Unit") {
         val actual   = """["hello", "there"]"""
         val expected = Left("(Expected empty list, got [hello, there])")
-        assertTrue(actual.fromJson[scala.Unit] == expected)
+        assert(actual.fromJson[scala.Unit])(objectEqualTo(expected))
       }
     ),
     suite("Name")(
       test("will decode an empty Name") {
         val actual   = "[]"
         val expected = Name.empty
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       },
       test("will decode a single Name") {
         val actual   = """["hello"]"""
         val expected = Name("Hello")
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       },
       test("will decode a Name") {
         val actual   = """["hello","there"]"""
         val expected = Name("HelloThere")
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       },
       test("will decode a Name fromString") {
         val actual   = """["hello","there"]"""
         val expected = Name.fromString("Hello.There")
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       },
       test("will decode a Name fromList") {
         val actual   = """["this","is","a","list"]"""
         val expected = Name.fromList(List("This", "is", "a", "list"))
-        assertTrue(actual.fromJson[Name] == Right(expected))
+        assert(actual.fromJson[Name])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Path")(
       test("will decode an empty Path") {
         val actual   = "[]"
         val expected = Path.empty
-        assertTrue(actual.fromJson[Path] == Right(expected))
+        assert(actual.fromJson[Path])(objectEqualTo(Right(expected)))
       },
       test("will decode a simple Path") {
         val actual   = """[["org"]]"""
         val expected = Path.fromString("org")
-        assertTrue(actual.fromJson[Path] == Right(expected))
+        assert(actual.fromJson[Path])(objectEqualTo(Right(expected)))
       },
       test("will decode a Path") {
         val actual   = """[["org"],["foo"],["bar"]]"""
         val expected = Path.fromString("org.foo.bar")
-        assertTrue(actual.fromJson[Path] == Right(expected))
+        assert(actual.fromJson[Path])(objectEqualTo(Right(expected)))
       }
     ),
     suite("ModulePath")(
       test("will decode an empty ModulePath") {
         val actual   = "[]"
         val expected = ModuleName(Path.empty)
-        assertTrue(actual.fromJson[ModuleName] == Right(expected))
+        assert(actual.fromJson[ModuleName])(objectEqualTo(Right(expected)))
       },
       test("will decode a simple ModulePath") {
         val actual   = """[["org"]]"""
         val expected = ModuleName(Path.fromString("org"))
-        assertTrue(actual.fromJson[ModuleName] == Right(expected))
+        assert(actual.fromJson[ModuleName])(objectEqualTo(Right(expected)))
       },
       test("will decode a ModulePath") {
         val actual   = """[["org"],["foo"],["bar"]]"""
         val expected = ModuleName(Path.fromString("org.foo.bar"))
-        assertTrue(actual.fromJson[ModuleName] == Right(expected))
+        assert(actual.fromJson[ModuleName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("PackageName")(
       test("will decode an empty PackageName") {
         val actual   = "[]"
         val expected = PackageName(Path.empty)
-        assertTrue(actual.fromJson[PackageName] == Right(expected))
+        assert(actual.fromJson[PackageName])(objectEqualTo(Right(expected)))
       },
       test("will decode a simple PackageName") {
         val actual   = """[["org"]]"""
         val expected = PackageName(Path.fromString("org"))
-        assertTrue(actual.fromJson[PackageName] == Right(expected))
+        assert(actual.fromJson[PackageName])(objectEqualTo(Right(expected)))
       },
       test("will decode a PackageName") {
         val actual   = """[["org"],["foo"],["bar"]]"""
         val expected = PackageName(Path.fromString("org.foo.bar"))
-        assertTrue(actual.fromJson[PackageName] == Right(expected))
+        assert(actual.fromJson[PackageName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("ModuleName")(
       test("will decode an empty ModuleName") {
         val actual   = "[[],[]]"
         val expected = QualifiedModuleName(Path.empty, Name.empty)
-        assertTrue(actual.fromJson[QualifiedModuleName] == Right(expected))
+        assert(actual.fromJson[QualifiedModuleName])(objectEqualTo(Right(expected)))
       },
       test("will decode a simple ModuleName") {
         val actual   = """[[["org"]],["src","test"]]"""
         val expected = QualifiedModuleName(Path.fromString("org"), Name.fromString("SrcTest"))
-        assertTrue(actual.fromJson[QualifiedModuleName] == Right(expected))
+        assert(actual.fromJson[QualifiedModuleName])(objectEqualTo(Right(expected)))
       },
       test("will decode a ModuleName") {
         val actual   = """[[["src"],["test"],["scala"]],["src","test"]]"""
         val expected = QualifiedModuleName(Path.fromString("src.test.scala"), Name.fromString("SrcTest"))
-        assertTrue(actual.fromJson[QualifiedModuleName] == Right(expected))
+        assert(actual.fromJson[QualifiedModuleName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("QName")(
       test("will decode an empty QName") {
         val actual   = "[[],[]]"
         val expected = QName(Path.empty, Name.empty)
-        assertTrue(actual.fromJson[QName] == Right(expected))
+        assert(actual.fromJson[QName])(objectEqualTo(Right(expected)))
       },
       test("will decode a QName") {
         val actual   = """[[["proper"],["path"]],["name"]]"""
         val expected = QName.fromString("Proper.Path:name").get
-        assertTrue(actual.fromJson[QName] == Right(expected))
+        assert(actual.fromJson[QName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("FQName")(
       test("will decode an empty FQName") {
         val actual   = "[[],[],[]]"
         val expected = FQName(Path.empty, Path.empty, Name.empty)
-        assertTrue(actual.fromJson[FQName] == Right(expected))
+        assert(actual.fromJson[FQName])(objectEqualTo(Right(expected)))
       },
       test("will decode a FQName") {
         val actual   = """[[["com"],["example"]],[["java","home"]],["morphir"]]"""
         val expected = FQName.fromString("Com.Example;JavaHome;morphir", ";")
-        assertTrue(actual.fromJson[FQName] == Right(expected))
+        assert(actual.fromJson[FQName])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Documented")(
       test("will decode Documented for Integer") {
         val actual   = """["This is an Integer 10",10]"""
         val expected = Documented("This is an Integer 10", 10)
-        assertTrue(actual.fromJson[Documented[Int]] == Right(expected))
+        assert(actual.fromJson[Documented[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Documented for String") {
         val actual   = """["This is a String","Hello"]"""
         val expected = Documented("This is a String", "Hello")
-        assertTrue(actual.fromJson[Documented[String]] == Right(expected))
+        assert(actual.fromJson[Documented[String]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("AccessControlled")(
       test("will decode AccessControlled for private Integer") {
         val actual   = """["private",10]"""
         val expected = AccessControlled(AccessControlled.Access.Private, 10)
-        assertTrue(actual.fromJson[AccessControlled[Int]] == Right(expected))
+        assert(actual.fromJson[AccessControlled[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode AccessControlled for public String") {
         val actual   = """["public","Hello"]"""
         val expected = AccessControlled(AccessControlled.Access.Public, "Hello")
-        assertTrue(actual.fromJson[AccessControlled[String]] == Right(expected))
+        assert(actual.fromJson[AccessControlled[String]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Field")(
       test("will decode Field for private Integer") {
         val actual   = """[["name"],10]"""
         val expected = Field(Name.fromString("Name"), 10)
-        assertTrue(actual.fromJson[Field[Int]] == Right(expected))
+        assert(actual.fromJson[Field[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Field for public String") {
         val actual = """[["string"],["public","Hello"]]"""
         val expected =
           Field(Name.fromString("String"), AccessControlled(AccessControlled.Access.Public, "Hello"))
-        assertTrue(actual.fromJson[Field[AccessControlled[String]]] == Right(expected))
+        assert(actual.fromJson[Field[AccessControlled[String]]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Literal")(
       test("will decode a BoolLiteral") {
         val actual   = """["bool_literal",true]"""
         val expected = BoolLiteral(true)
-        assertTrue(actual.fromJson[BoolLiteral] == Right(expected))
+        assert(actual.fromJson[BoolLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode a CharLiteral") {
         val actual   = """["char_literal","x"]"""
         val expected = CharLiteral('x')
-        assertTrue(actual.fromJson[CharLiteral] == Right(expected))
+        assert(actual.fromJson[CharLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode a DecimalLiteral") {
         val actual   = """["decimal_literal","1.23456789"]"""
         val expected = DecimalLiteral(new java.math.BigDecimal("1.23456789"))
-        assertTrue(actual.fromJson[DecimalLiteral] == Right(expected))
+        assert(actual.fromJson[DecimalLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode a FloatLiteral") {
         val actual   = """["float_literal",1.3232]"""
         val expected = FloatLiteral(1.3232d)
 
-        assertTrue(actual.fromJson[FloatLiteral] == Right(expected))
+        assert(actual.fromJson[FloatLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode a StringLiteral") {
         val actual   = """["string_literal","hello"]"""
         val expected = StringLiteral("hello")
-        assertTrue(actual.fromJson[StringLiteral] == Right(expected))
+        assert(actual.fromJson[StringLiteral])(objectEqualTo(Right(expected)))
       },
       test("will decode an WholeNumberLiteral") {
         val actual   = """["int_literal",321321]"""
         val expected = WholeNumberLiteral(321321L)
-        assertTrue(actual.fromJson[WholeNumberLiteral] == Right(expected))
+        assert(actual.fromJson[WholeNumberLiteral])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Type")(
@@ -295,14 +296,14 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
       test("will decode empty Constructor") {
         val actual   = """[]"""
         val expected = org.finos.morphir.ir.Type.Constructors[Int](Map.empty)
-        assertTrue(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]] == Right(expected))
+        assert(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Constructors with one constructor") {
         val name   = Name.fromString("name")
         val actual = """[[["name"],[[["name"],["variable",123,["f"]]]]]]"""
         val expected =
           org.finos.morphir.ir.Type.Constructors[Int](Map((name, zio.Chunk((name, variable[Int](123, "f"))))))
-        assertTrue(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]] == Right(expected))
+        assert(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Constructors") {
         val name1 = Name.fromString("name1")
@@ -317,7 +318,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
             (name2, zio.Chunk((name3, variable[Int](678, "h")), (name4, variable[Int](789, "i"))))
           )
         )
-        assertTrue(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]] == Right(expected))
+        assert(actual.fromJson[org.finos.morphir.ir.Type.Constructors[Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("TypeDefinition")(
@@ -407,7 +408,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
           """{"inputTypes":[[["name","1"],1,["variable",345,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",345,["g"]],"body":["unit",1]}"""
         val expected =
           ValueDefinition[Int, Int](inputParams, variable[Int](345, "g"), Value.Unit(1))
-        assertTrue(actual.fromJson[ValueDefinition[Int, Int]] == Right(expected))
+        assert(actual.fromJson[ValueDefinition[Int, Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("ValueSpecification")(
@@ -419,7 +420,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val actual =
           """{"inputs":[[["name","1"],["variable",345,["g"]]],[["name","2"],["variable",678,["h"]]]],"outputs":["variable",111,["f"]]}"""
         val expected = ValueSpecification[Int](inputs, variable[Int](111, "f"))
-        assertTrue(actual.fromJson[ValueSpecification[Int]] == Right(expected))
+        assert(actual.fromJson[ValueSpecification[Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Pattern")(
@@ -456,7 +457,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
       test("will decode LiteralPattern") {
         val actual   = """["literal_pattern",1,["string_literal","hello"]]"""
         val expected = Pattern.LiteralPattern[Int](1, StringLiteral("hello"))
-        assertTrue(actual.fromJson[Pattern.LiteralPattern[Int]] == Right(expected))
+        assert(actual.fromJson[Pattern.LiteralPattern[Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode HeadTailPattern") {
         val actual = """["head_tail_pattern",1,["wildcard_pattern",1],["empty_list_pattern",2]]"""
@@ -517,7 +518,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val actual =
           """{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["variable",345,["g"]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["variable",345,["g"]]],[["name","2"],["variable",678,["h"]]]],"outputs":["variable",111,["f"]]}]]]}"""
         val expected = ModuleSpecification[Int](typeMap, valueMap)
-        assertTrue(actual.fromJson[ModuleSpecification[Int]] == Right(expected))
+        assert(actual.fromJson[ModuleSpecification[Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("PackageSpecification")(
@@ -542,7 +543,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val expected = PackageSpecification[Int](Map(modName1 -> modSpec, modName2 -> modSpec))
         val actual =
           """{"modules":[{"name":[[["org"]],["src"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["variable",345,["g"]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["variable",345,["g"]]],[["name","2"],["variable",678,["h"]]]],"outputs":["variable",111,["f"]]}]]]}},{"name":[[["org"]],["test"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["variable",345,["g"]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["variable",345,["g"]]],[["name","2"],["variable",678,["h"]]]],"outputs":["variable",111,["f"]]}]]]}}]}"""
-        assertTrue(actual.fromJson[PackageSpecification[Int]] == Right(expected))
+        assert(actual.fromJson[PackageSpecification[Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("ModuleDefinition")(
@@ -573,7 +574,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val expected = ModuleDefinition[Int, Int](typeMap, valueMap)
         val actual =
           """{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["variable",345,["g"]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],1,["variable",345,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",345,["g"]],"body":["constructor",1,[[["test"]],[["java","home"]],["morphir"]]]}]]]]}"""
-        assertTrue(actual.fromJson[ModuleDefinition[Int, Int]] == Right(expected))
+        assert(actual.fromJson[ModuleDefinition[Int, Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("PackageDefinition")(
@@ -614,7 +615,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
           )
         )
 
-        assertTrue(actual.fromJson[PackageDefinition[Int, Int]] == Right(expected))
+        assert(actual.fromJson[PackageDefinition[Int, Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Value")(
@@ -622,46 +623,46 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val unitCase = Value.Unit(6)
         val actual   = """["apply",3,["unit",6],["unit",6]]"""
         val expected = Value.Apply(3, unitCase, unitCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - ConstructorCase") {
         val name     = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val actual   = """["constructor",3,[[["com"],["example"]],[["java","home"]],["morphir"]]]"""
         val expected = Value.Constructor(3, name)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - DestructureCase") {
         val pattern  = Pattern.WildcardPattern[Int](1)
         val unitCase = Value.Unit(6)
         val actual   = """["destructure",3,["wildcard_pattern",1],["unit",6],["unit",6]]"""
         val expected = Value.Destructure(3, pattern, unitCase, unitCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - FieldCase") {
         val name     = Name("Hello")
         val unitCase = Value.Unit(6)
         val actual   = """["field",3,["unit",6],["hello"]]"""
         val expected = Value.Field(3, unitCase, name)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - FieldFunctionCase") {
         val actual   = """["field_function",3,["hello"]]"""
         val expected = Value.FieldFunction(3, Name("Hello"))
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - IfThenElseCase") {
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val unitCase          = Value.Unit(6)
         val actual            = """["if_then_else",3,["unit",6],["field_function",3,["hello"]],["unit",6]]"""
         val expected          = Value.IfThenElse(3, unitCase, fieldFunctionCase, unitCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - LambdaCase") {
         val pattern           = Pattern.WildcardPattern[Int](1)
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val actual            = """["lambda",3,["wildcard_pattern",1],["field_function",3,["hello"]]]"""
         val expected          = Value.Lambda(3, pattern, fieldFunctionCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - LetDefinitionCase") {
         val inputParams = zio.Chunk(
@@ -677,7 +678,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
           """["let_definition",3,["hi"],{"inputTypes":[[["name","1"],1,["variable",444,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",345,["g"]],"body":["literal",3,["bool_literal",true]]},["field_function",3,["hello"]]]"""
         val expected =
           Value.LetDefinition(3, Name("Hi"), valueDefinition, fieldFunctionCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - LetRecursionCase") {
         val inputParams = zio.Chunk(
@@ -694,20 +695,20 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val actual =
           """["let_recursion",3,[[["key","1"],{"inputTypes":[[["name","1"],1,["variable",444,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",333,["x"]],"body":["literal",3,["bool_literal",true]]}],[["key","2"],{"inputTypes":[[["name","1"],1,["variable",444,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",333,["x"]],"body":["literal",3,["bool_literal",true]]}]],["field_function",3,["hello"]]]"""
         val expected = Value.LetRecursion(3, valueDefinitions, fieldFunctionCase)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - ListCase") {
         val unitCase          = Value.Unit(6)
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val actual            = """["list",3,[["unit",6],["field_function",3,["hello"]]]]"""
         val expected          = Value.List(3, zio.Chunk[Value[Int, Int]](unitCase, fieldFunctionCase))
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - LiteralCase") {
         val literal  = BoolLiteral(true)
         val actual   = """["literal",3,["bool_literal",true]]"""
         val expected = Value.Literal(3, literal)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - PatternMatchCase") {
         val unitCase          = Value.Unit(6)
@@ -715,7 +716,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val patterns          = zio.Chunk((Pattern.WildcardPattern[Int](12), fieldFunctionCase))
         val actual   = """["pattern_match",3,["unit",6],[[["wildcard_pattern",12],["field_function",3,["hello"]]]]]"""
         val expected = Value.PatternMatch(3, unitCase, patterns)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - RecordCase") {
         val unitCase          = Value.Unit(6)
@@ -723,13 +724,13 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val fields            = zio.Chunk((Name("hello"), fieldFunctionCase), (Name("there"), unitCase))
         val actual            = """["record",3,[[["hello"],["field_function",3,["hello"]]],[["there"],["unit",6]]]]"""
         val expected          = Value.Record(3, fields)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - ReferenceCase") {
         val name     = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val actual   = """["reference",3,[[["com"],["example"]],[["java","home"]],["morphir"]]]"""
         val expected = Value.Reference(3, name)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - TupleCase") {
         val unitCase          = Value.Unit(6)
@@ -737,7 +738,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val elements          = zio.Chunk(unitCase, fieldFunctionCase)
         val actual            = """["tuple",3,[["unit",6],["field_function",3,["hello"]]]]"""
         val expected          = Value.Tuple(3, elements)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - UpdateRecordCase") {
         val unitCase          = Value.Unit(6)
@@ -746,17 +747,17 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val actual =
           """["update_record",3,["unit",6],[[["hello"],["field_function",3,["hello"]]],[["there"],["unit",6]]]]"""
         val expected = Value.UpdateRecord(3, unitCase, fields)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - UnitCase") {
         val actual   = """["unit",6]"""
         val expected = Value.Unit(6)
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       },
       test("will decode Value - VariableCase") {
         val actual   = """["variable",3,["hello"]]"""
         val expected = Value.Variable(3, Name("hello"))
-        assertTrue(actual.fromJson[Value[Int, Int]] == Right(expected))
+        assert(actual.fromJson[Value[Int, Int]])(objectEqualTo(Right(expected)))
       }
     ),
     suite("Distribution")(
@@ -813,10 +814,8 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val expected = Library(packageName, dependencies, packageDef)
         val actual =
           """["library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[{"name":[[["org"]],["src"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}},{"name":[[["org"]],["test"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}}]}]],{"modules":[{"name":[[["org"]],["src"]],"def":["public",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]},{"name":[[["org"]],["test"]],"def":["private",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]}]}]"""
-        assertTrue(
-          actual.fromJson[Library] == Right(expected),
-          actual.fromJson[Distribution] == Right(expected)
-        )
+        assert(actual.fromJson[Library])(objectEqualTo(Right(expected))) &&
+        assert(actual.fromJson[Distribution])(objectEqualTo(Right(expected)))
       }
     ),
     suite("MorphirIRFile")(
@@ -873,9 +872,7 @@ object MorphirJsonDecodingSpecV1 extends ZIOSpecDefault {
         val expected = MorphirIRFile(MorphirIRVersion.V1_0, Library(packageName, dependencies, packageDef))
         val actual =
           """{"formatVersion":1,"distribution":["library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[{"name":[[["org"]],["src"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}},{"name":[[["org"]],["test"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}}]}]],{"modules":[{"name":[[["org"]],["src"]],"def":["public",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]},{"name":[[["org"]],["test"]],"def":["private",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]}]}]}"""
-        assertTrue(
-          actual.fromJson[MorphirIRFile] == Right(expected)
-        )
+        assert(actual.fromJson[MorphirIRFile])(objectEqualTo(Right(expected)))
       }
     )
   )

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonEncodingSpec.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonEncodingSpec.scala
@@ -21,7 +21,8 @@ import org.finos.morphir.ir.PackageModule.{
 import org.finos.morphir.ir.Type.{Definition as TypeDefinition, Specification as TypeSpecification, *}
 import org.finos.morphir.ir.Value.{Definition => ValueDefinition, Pattern, Specification => ValueSpecification, Value}
 import org.finos.morphir.ir.json.MorphirJsonSupport._
-import zio.test.*
+import org.finos.morphir.ir.json.util.CustomAssert._
+import zio.test._
 
 object MorphirJsonEncodingSpec extends ZIOSpecDefault {
   def spec = suite("Json Encoding Suite")(
@@ -29,109 +30,109 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
       test("will encode a Unit") {
         val actual   = ()
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Name")(
       test("will encode an empty Name") {
         val actual   = Name.empty
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a single Name") {
         val actual   = Name("Hello")
         val expected = """["hello"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Name") {
         val actual   = Name("HelloThere")
         val expected = """["hello","there"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Name fromString") {
         val actual   = Name.fromString("Hello.There")
         val expected = """["hello","there"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Name fromList") {
         val actual   = Name.fromList(List("This", "is", "a", "list"))
         val expected = """["this","is","a","list"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Path")(
       test("will encode an empty Path") {
         val actual   = Path.empty
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a simple Path") {
         val actual   = Path.fromString("org")
         val expected = """[["org"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Path") {
         val actual   = Path.fromString("org.foo.bar")
         val expected = """[["org"],["foo"],["bar"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ModulePath")(
       test("will encode an empty Path") {
         val actual   = ModuleName(Path.empty)
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a simple Path") {
         val actual   = ModuleName(Path.fromString("org"))
         val expected = """[["org"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Path") {
         val actual   = ModuleName(Path.fromString("org.foo.bar"))
         val expected = """[["org"],["foo"],["bar"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("PackageName")(
       test("will encode an empty Path") {
         val actual   = PackageName(Path.empty)
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a simple Path") {
         val actual   = PackageName(Path.fromString("org"))
         val expected = """[["org"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Path") {
         val actual   = PackageName(Path.fromString("org.foo.bar"))
         val expected = """[["org"],["foo"],["bar"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ModuleName")(
       test("will encode an empty ModuleName") {
         val actual   = QualifiedModuleName(Path.empty, Name.empty)
         val expected = "[[],[]]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a simple ModuleName") {
         val actual   = QualifiedModuleName(Path.fromString("org"), Name.fromString("SrcTest"))
         val expected = """[[["org"]],["src","test"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a ModuleName") {
         val actual   = QualifiedModuleName(Path.fromString("src.test.scala"), Name.fromString("SrcTest"))
         val expected = """[[["src"],["test"],["scala"]],["src","test"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("QName")(
       test("will encode an empty QName") {
         val actual   = QName(Path.empty, Name.empty)
         val expected = "[[],[]]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a QName") {
         val actual   = QName.fromString("Proper.Path:name")
@@ -143,98 +144,98 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
       test("will encode an empty FQName") {
         val actual   = FQName(Path.empty, Path.empty, Name.empty)
         val expected = "[[],[],[]]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a FQName") {
         val actual   = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val expected = """[[["com"],["example"]],[["java","home"]],["morphir"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Documented")(
       test("will encode Documented for Integer") {
         val actual   = Documented("This is an Integer 10", 10)
         val expected = """{"doc":"This is an Integer 10","value":10}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Documented for String") {
         val actual   = Documented("This is a String", "Hello")
         val expected = """{"doc":"This is a String","value":"Hello"}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("AccessControlled")(
       test("will encode AccessControlled for private Integer") {
         val actual   = AccessControlled(AccessControlled.Access.Private, 10)
         val expected = """{"access":"Private","value":10}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode AccessControlled for public String") {
         val actual   = AccessControlled(AccessControlled.Access.Public, "Hello")
         val expected = """{"access":"Public","value":"Hello"}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Field")(
       test("will encode Field for private Integer") {
         val actual   = Field(Name.fromString("Name"), AccessControlled(AccessControlled.Access.Private, 10))
         val expected = """{"name":["name"],"tpe":{"access":"Private","value":10}}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Field for public String") {
         val actual =
           Field(Name.fromString("String"), AccessControlled(AccessControlled.Access.Public, "Hello"))
         val expected = """{"name":["string"],"tpe":{"access":"Public","value":"Hello"}}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Literal")(
       test("will encode a BoolLiteral") {
         val actual   = BoolLiteral(true)
         val expected = """["BoolLiteral",true]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a CharLiteral") {
         val actual   = CharLiteral('x')
         val expected = """["CharLiteral","x"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a DecimalLiteral") {
         val actual   = DecimalLiteral(new java.math.BigDecimal("1.23456789"))
         val expected = """["DecimalLiteral","1.23456789"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a FloatLiteral") {
         val actual   = FloatLiteral(1.3232d)
         val expected = """["FloatLiteral",1.3232]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a StringLiteral") {
         val actual   = StringLiteral("hello")
         val expected = """["StringLiteral","hello"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode an WholeNumberLiteral") {
         val actual   = WholeNumberLiteral(321321L)
         val expected = """["WholeNumberLiteral",321321]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Type")(
       test("will encode TypeCase.Unit") {
         val actual   = unit[Int](1234)
         val expected = """["Unit",1234]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.VariableCase") {
         val actual   = variable[Int](1234, "x")
         val expected = """["Variable",1234,["x"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Field") {
         val actual   = Field(Name("someField"), variable[Int](1234, "x"))
         val expected = """{"name":["some","field"],"tpe":["Variable",1234,["x"]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.RecordCase") {
         val var1   = Field(Name("first"), variable[Int](123, "f"))
@@ -242,7 +243,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = record(1, zio.Chunk(var1, var2))
         val expected =
           """["Record",1,[{"name":["first"],"tpe":["Variable",123,["f"]]},{"name":["second"],"tpe":["Variable",345,["g"]]}]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.ExtensibleRecordCase") {
         val var1   = Field(Name("first"), variable[Int](123, "f"))
@@ -250,14 +251,14 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = extensibleRecord(1, Name.fromString("someName"), zio.Chunk(var1, var2))
         val expected =
           """["ExtensibleRecord",1,["some","name"],[{"name":["first"],"tpe":["Variable",123,["f"]]},{"name":["second"],"tpe":["Variable",345,["g"]]}]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.TupleCase") {
         val var1     = variable[Int](123, "f")
         val var2     = variable[Int](345, "g")
         val actual   = tuple(1, var1, var2)
         val expected = """["Tuple",1,[["Variable",123,["f"]],["Variable",345,["g"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.ReferenceCase") {
         val var1   = variable[Int](123, "f")
@@ -265,7 +266,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = reference(1, FQName.fromString("test:JavaHome:morphir"), zio.Chunk(var1, var2))
         val expected =
           """["Reference",1,[[["test"]],[["java","home"]],["morphir"]],[["Variable",123,["f"]],["Variable",345,["g"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.FunctionCase") {
         val var1   = variable[Int](123, "f")
@@ -273,20 +274,20 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = function(1, var1, var2)
         val expected =
           """["Function",1,["Variable",123,["f"]],["Variable",345,["g"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Constructors")(
       test("will encode empty Constructor") {
         val actual   = Constructors[Int](Map.empty)
         val expected = """[]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Constructors with one constructor") {
         val name     = Name.fromString("name")
         val actual   = Constructors[Int](Map((name, zio.Chunk((name, variable[Int](123, "f"))))))
         val expected = """[[["name"],[[["name"],["Variable",123,["f"]]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Constructors") {
         val name1 = Name.fromString("name1")
@@ -301,7 +302,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         )
         val expected =
           """[[["name","1"],[[["name","1"],["Variable",123,["f"]]],[["name","2"],["Variable",345,["g"]]]]],[["name","2"],[[["name","3"],["Variable",678,["h"]]],[["name","4"],["Variable",789,["i"]]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("org.finos.morphir.ir.Type.Definition")(
@@ -310,7 +311,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val name2    = Name.fromString("name2")
         val actual   = TypeDefinition.TypeAlias[Int](zio.Chunk(name1, name2), variable[Int](345, "g"))
         val expected = """["TypeAliasDefinition",[["name","1"],["name","2"]],["Variable",345,["g"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode CustomType") {
         val name1 = Name.fromString("name1")
@@ -329,7 +330,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = TypeDefinition.CustomType[Int](zio.Chunk(name1, name2), ctors)
         val expected =
           """["CustomTypeDefinition",[["name","1"],["name","2"]],{"access":"Public","value":[[["name","1"],[[["name","1"],["Variable",123,["f"]]],[["name","2"],["Variable",345,["g"]]]]],[["name","2"],[[["name","3"],["Variable",678,["h"]]],[["name","4"],["Variable",789,["i"]]]]]]}]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("org.finos.morphir.ir.Type.Specification")(
@@ -339,7 +340,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual =
           TypeSpecification.TypeAliasSpecification[Int](zio.Chunk(name1, name2), variable[Int](345, "g"))
         val expected = """["TypeAliasSpecification",[["name","1"],["name","2"]],["Variable",345,["g"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode CustomTypeSpecification") {
         val name1 = Name.fromString("name1")
@@ -355,7 +356,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = TypeSpecification.CustomTypeSpecification[Int](zio.Chunk(name1, name2), ctors)
         val expected =
           """["CustomTypeSpecification",[["name","1"],["name","2"]],[[["name","1"],[[["name","1"],["Variable",123,["f"]]],[["name","2"],["Variable",345,["g"]]]]],[["name","2"],[[["name","3"],["Variable",678,["h"]]],[["name","4"],["Variable",789,["i"]]]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode OpaqueTypeSpecification") {
         val name1  = Name.fromString("name1")
@@ -363,14 +364,14 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = TypeSpecification.OpaqueTypeSpecification(zio.Chunk(name1, name2))
         val expected =
           """["OpaqueTypeSpecification",[["name","1"],["name","2"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Pattern")(
       test("will encode AsPattern") {
         val actual   = Pattern.AsPattern[Int](1, Pattern.WildcardPattern[Int](1), Name.fromString("wildCard"))
         val expected = """["as_pattern",1,["wildcard_pattern",1],["wild","card"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode ConstructorPattern") {
         val patterns: zio.Chunk[Pattern[Int]] = zio.Chunk(
@@ -381,22 +382,22 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = Pattern.ConstructorPattern[Int](1, FQName.fromString("test:JavaHome:morphir"), patterns)
         val expected =
           """["constructor_pattern",1,[[["test"]],[["java","home"]],["morphir"]],[["wildcard_pattern",1],["empty_list_pattern",2],["as_pattern",1,["wildcard_pattern",1],["wild","card"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode EmptyListPattern") {
         val actual   = Pattern.EmptyListPattern[Int](1)
         val expected = """["empty_list_pattern",1]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode LiteralPattern") {
         val actual   = Pattern.LiteralPattern[Int](1, StringLiteral("hello"))
         val expected = """["literal_pattern",1,["StringLiteral","hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode HeadTailPattern") {
         val actual = Pattern.HeadTailPattern[Int](1, Pattern.WildcardPattern[Int](1), Pattern.EmptyListPattern[Int](2))
         val expected = """["head_tail_pattern",1,["wildcard_pattern",1],["empty_list_pattern",2]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TuplePattern") {
         val patterns: zio.Chunk[Pattern[Int]] = zio.Chunk(
@@ -407,17 +408,17 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = Pattern.TuplePattern[Int](1, patterns)
         val expected =
           """["tuple_pattern",1,[["wildcard_pattern",1],["unit_pattern",2],["as_pattern",1,["wildcard_pattern",1],["wild","card"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode UnitPattern") {
         val actual   = Pattern.UnitPattern[Int](1)
         val expected = """["unit_pattern",1]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode WildcardPattern") {
         val actual   = Pattern.WildcardPattern[Int](1)
         val expected = """["wildcard_pattern",1]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ValueDefinition")(
@@ -430,7 +431,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
           ValueDefinition[Int, Int](inputParams, variable[Int](345, "g"), Value.Unit(1))
         val expected =
           """{"inputTypes":[[["name","1"],1,["Variable",345,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",345,["g"]],"body":["unit",1]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ValueSpecification")(
@@ -442,7 +443,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = ValueSpecification[Int](inputs, variable[Int](111, "f"))
         val expected =
           """{"inputs":[[["name","1"],["Variable",345,["g"]]],[["name","2"],["Variable",678,["h"]]]],"outputs":["Variable",111,["f"]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ModuleSpecification")(
@@ -464,7 +465,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = ModuleSpecification[Int](typeMap, valueMap)
         val expected =
           """{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Variable",345,["g"]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Variable",345,["g"]]],[["name","2"],["Variable",678,["h"]]]],"outputs":["Variable",111,["f"]]}}]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ModuleDefinition")(
@@ -494,7 +495,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = ModuleDefinition[Int, Int](typeMap, valueMap)
         val expected =
           """{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Variable",345,["g"]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],1,["Variable",345,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",345,["g"]],"body":["constructor",1,[[["test"]],[["java","home"]],["morphir"]]]}}}]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("PackageSpecification")(
@@ -519,7 +520,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual  = PackageSpecification[Int](Map(modName1 -> modSpec, modName2 -> modSpec))
         val expected =
           """{"modules":[[[[["org"]],["src"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Variable",345,["g"]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Variable",345,["g"]]],[["name","2"],["Variable",678,["h"]]]],"outputs":["Variable",111,["f"]]}}]]}],[[[["org"]],["test"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Variable",345,["g"]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Variable",345,["g"]]],[["name","2"],["Variable",678,["h"]]]],"outputs":["Variable",111,["f"]]}}]]}]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("PackageDefinition")(
@@ -560,7 +561,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
 
         val expected =
           """{"modules":[[[[["org"]],["src"]],{"access":"Public","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Variable",345,["g"]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],1,["Variable",345,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",345,["g"]],"body":["constructor",1,[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}],[[[["org"]],["test"]],{"access":"Public","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Variable",345,["g"]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],1,["Variable",345,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",345,["g"]],"body":["constructor",1,[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Value")(
@@ -568,46 +569,46 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val unitCase = Value.Unit(6)
         val actual   = Value.Apply[Unit, Int](3, unitCase, unitCase)
         val expected = """["apply",3,["unit",6],["unit",6]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Constructor") {
         val name     = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val actual   = Value.Constructor(3, name)
         val expected = """["constructor",3,[[["com"],["example"]],[["java","home"]],["morphir"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Destructure") {
         val pattern  = Pattern.WildcardPattern[Int](1)
         val unitCase = Value.Unit(6)
         val actual   = Value.Destructure[Unit, Int](3, pattern, unitCase, unitCase)
         val expected = """["destructure",3,["wildcard_pattern",1],["unit",6],["unit",6]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Field") {
         val name     = Name("Hello")
         val unitCase = Value.Unit(6)
         val actual   = Value.Field[Unit, Int](3, unitCase, name)
         val expected = """["field",3,["unit",6],["hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - FieldFunction") {
         val actual   = Value.FieldFunction(3, Name("Hello"))
         val expected = """["field_function",3,["hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - IfThenElse") {
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val unitCase          = Value.Unit(6)
         val actual            = Value.IfThenElse[Unit, Int](3, unitCase, fieldFunctionCase, unitCase)
         val expected          = """["if_then_else",3,["unit",6],["field_function",3,["hello"]],["unit",6]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Lambda") {
         val pattern           = Pattern.WildcardPattern[Int](1)
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val actual            = Value.Lambda[Unit, Int](3, pattern, fieldFunctionCase)
         val expected          = """["lambda",3,["wildcard_pattern",1],["field_function",3,["hello"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - LetDefinition") {
         val inputParams = zio.Chunk(
@@ -622,7 +623,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = Value.LetDefinition(3, Name("Hi"), valueDefinition, fieldFunctionCase)
         val expected =
           """["let_definition",3,["hi"],{"inputTypes":[[["name","1"],1,["Variable",444,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",345,["g"]],"body":["literal",3,["BoolLiteral",true]]},["field_function",3,["hello"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       // test("will encode and decode Value - LetDefinition - with Any") {
       //   object Refs {
@@ -714,20 +715,20 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual            = Value.LetRecursion(3, valueDefinitions, fieldFunctionCase)
         val expected =
           """["let_recursion",3,[[["key","1"],{"inputTypes":[[["name","1"],1,["Variable",444,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",333,["x"]],"body":["literal",3,["BoolLiteral",true]]}],[["key","2"],{"inputTypes":[[["name","1"],1,["Variable",444,["g"]]],[["name","2"],2,["Variable",678,["h"]]]],"outputType":["Variable",333,["x"]],"body":["literal",3,["BoolLiteral",true]]}]],["field_function",3,["hello"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - ListCase") {
         val unitCase          = Value.Unit(6)
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val actual            = Value.List(3, zio.Chunk[Value[Int, Int]](unitCase, fieldFunctionCase))
         val expected          = """["list",3,[["unit",6],["field_function",3,["hello"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Literal") {
         val literal  = BoolLiteral(true)
         val actual   = Value.Literal(3, literal)
         val expected = """["literal",3,["BoolLiteral",true]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - PatternMatch") {
         val unitCase          = Value.Unit(6)
@@ -735,7 +736,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val patterns          = zio.Chunk((Pattern.WildcardPattern[Int](12), fieldFunctionCase))
         val actual            = Value.PatternMatch[Unit, Int](3, unitCase, patterns)
         val expected = """["pattern_match",3,["unit",6],[[["wildcard_pattern",12],["field_function",3,["hello"]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Record") {
         val unitCase          = Value.Unit(6)
@@ -743,13 +744,13 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val fields            = zio.Chunk((Name("hello"), fieldFunctionCase), (Name("there"), unitCase))
         val actual            = Value.Record[Unit, Int](3, fields)
         val expected          = """["record",3,[[["hello"],["field_function",3,["hello"]]],[["there"],["unit",6]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Reference") {
         val name     = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val actual   = Value.Reference(3, name)
         val expected = """["reference",3,[[["com"],["example"]],[["java","home"]],["morphir"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Tuple") {
         val unitCase          = Value.Unit(6)
@@ -757,7 +758,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val elements          = zio.Chunk(unitCase, fieldFunctionCase)
         val actual            = Value.Tuple[Unit, Int](3, elements)
         val expected          = """["tuple",3,[["unit",6],["field_function",3,["hello"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - UpdateRecord") {
         val unitCase          = Value.Unit(6)
@@ -766,17 +767,17 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual            = Value.UpdateRecord[Unit, Int](3, unitCase, fields)
         val expected =
           """["update_record",3,["unit",6],[[["hello"],["field_function",3,["hello"]]],[["there"],["unit",6]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Unit") {
         val actual   = Value.Unit(6)
         val expected = """["unit",6]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Variable") {
         val actual   = Value.Variable(3, Name("hello"))
         val expected = """["variable",3,["hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Distribution")(
@@ -833,7 +834,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = Library(packageName, dependencies, packageDef)
         val expected =
           """["Library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[[[[["org"]],["src"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}],[[[["org"]],["test"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}]]}]],{"modules":[[[[["org"]],["src"]],{"access":"Public","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}],[[[["org"]],["test"]],{"access":"Private","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}]]}]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("MorphirIRFile")(
@@ -890,7 +891,7 @@ object MorphirJsonEncodingSpec extends ZIOSpecDefault {
         val actual = MorphirIRFile(MorphirIRVersion.V2_0, Library(packageName, dependencies, packageDef))
         val expected =
           """{"formatVersion":2,"distribution":["Library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[[[[["org"]],["src"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}],[[[["org"]],["test"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}]]}]],{"modules":[[[[["org"]],["src"]],{"access":"Public","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}],[[[["org"]],["test"]],{"access":"Private","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}]]}]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     )
   )

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonEncodingSpecV1.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonEncodingSpecV1.scala
@@ -21,7 +21,8 @@ import org.finos.morphir.ir.PackageModule.{
 import org.finos.morphir.ir.Type.{Definition as TypeDefinition, Specification as TypeSpecification, *}
 import org.finos.morphir.ir.Value.{Definition => ValueDefinition, Pattern, Specification => ValueSpecification, Value}
 import org.finos.morphir.ir.json.MorphirJsonSupportV1._
-import zio.test.*
+import org.finos.morphir.ir.json.util.CustomAssert._
+import zio.test._
 
 object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
   def spec = suite("Json Encoding Suite - V1")(
@@ -29,109 +30,109 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
       test("will encode a Unit") {
         val actual   = ()
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Name")(
       test("will encode an empty Name") {
         val actual   = Name.empty
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a single Name") {
         val actual   = Name("Hello")
         val expected = """["hello"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Name") {
         val actual   = Name("HelloThere")
         val expected = """["hello","there"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Name fromString") {
         val actual   = Name.fromString("Hello.There")
         val expected = """["hello","there"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Name fromList") {
         val actual   = Name.fromList(List("This", "is", "a", "list"))
         val expected = """["this","is","a","list"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Path")(
       test("will encode an empty Path") {
         val actual   = Path.empty
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a simple Path") {
         val actual   = Path.fromString("org")
         val expected = """[["org"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Path") {
         val actual   = Path.fromString("org.foo.bar")
         val expected = """[["org"],["foo"],["bar"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ModuleName")(
       test("will encode an empty Path") {
         val actual   = ModuleName(Path.empty)
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a simple Path") {
         val actual   = ModuleName(Path.fromString("org"))
         val expected = """[["org"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Path") {
         val actual   = ModuleName(Path.fromString("org.foo.bar"))
         val expected = """[["org"],["foo"],["bar"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("PackageName")(
       test("will encode an empty Path") {
         val actual   = PackageName(Path.empty)
         val expected = "[]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a simple Path") {
         val actual   = PackageName(Path.fromString("org"))
         val expected = """[["org"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a Path") {
         val actual   = PackageName(Path.fromString("org.foo.bar"))
         val expected = """[["org"],["foo"],["bar"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ModuleName")(
       test("will encode an empty ModuleName") {
         val actual   = QualifiedModuleName(Path.empty, Name.empty)
         val expected = "[[],[]]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a simple ModuleName") {
         val actual   = QualifiedModuleName(Path.fromString("org"), Name.fromString("SrcTest"))
         val expected = """[[["org"]],["src","test"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a ModuleName") {
         val actual   = QualifiedModuleName(Path.fromString("src.test.scala"), Name.fromString("SrcTest"))
         val expected = """[[["src"],["test"],["scala"]],["src","test"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("QName")(
       test("will encode an empty QName") {
         val actual   = QName(Path.empty, Name.empty)
         val expected = "[[],[]]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a QName") {
         val actual   = QName.fromString("Proper.Path:name")
@@ -143,105 +144,105 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
       test("will encode an empty FQName") {
         val actual   = FQName(Path.empty, Path.empty, Name.empty)
         val expected = "[[],[],[]]"
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a FQName") {
         val actual   = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val expected = """[[["com"],["example"]],[["java","home"]],["morphir"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Documented")(
       test("will encode Documented for Integer") {
         val actual   = Documented("This is an Integer 10", 10)
         val expected = """["This is an Integer 10",10]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Documented for String") {
         val actual   = Documented("This is a String", "Hello")
         val expected = """["This is a String","Hello"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("AccessControlled")(
       test("will encode AccessControlled for private Integer") {
         val actual   = AccessControlled(AccessControlled.Access.Private, 10)
         val expected = """["private",10]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode AccessControlled for public String") {
         val actual   = AccessControlled(AccessControlled.Access.Public, "Hello")
         val expected = """["public","Hello"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Field")(
       test("will encode Field for private Integer") {
         val actual   = Field(Name.fromString("Name"), AccessControlled(AccessControlled.Access.Private, 10))
         val expected = """[["name"],["private",10]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Field for public String") {
         val actual =
           Field(Name.fromString("String"), AccessControlled(AccessControlled.Access.Public, "Hello"))
         val expected = """[["string"],["public","Hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Literal")(
       test("will encode a BoolLiteral") {
         val actual   = BoolLiteral(true)
         val expected = """["bool_literal",true]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a CharLiteral") {
         val actual   = CharLiteral('x')
         val expected = """["char_literal","x"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a DecimalLiteral") {
         val actual   = DecimalLiteral(new java.math.BigDecimal("1.23456789"))
         val expected = """["decimal_literal","1.23456789"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a FloatLiteral") {
         val actual   = FloatLiteral(1.3232d)
         val expected = """["float_literal",1.3232]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode a StringLiteral") {
         val actual   = StringLiteral("hello")
         val expected = """["string_literal","hello"]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode an WholeNumberLiteral") {
         val actual   = WholeNumberLiteral(321321L)
         val expected = """["int_literal",321321]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Type")(
       test("will encode TypeCase.Unit") {
         val actual   = unit[Int](1234)
         val expected = """["unit",1234]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.VariableCase") {
         val actual   = variable[Int](1234, "x")
         val expected = """["variable",1234,["x"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Field") {
         val actual   = Field(Name("someField"), variable[Int](1234, "x"))
         val expected = """[["some","field"],["variable",1234,["x"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.RecordCase") {
         val var1     = Field(Name("first"), variable[Int](123, "f"))
         val var2     = Field(Name("second"), variable[Int](345, "g"))
         val actual   = record(1, zio.Chunk(var1, var2))
         val expected = """["record",1,[[["first"],["variable",123,["f"]]],[["second"],["variable",345,["g"]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.ExtensibleRecordCase") {
         val var1   = Field(Name("first"), variable[Int](123, "f"))
@@ -249,14 +250,14 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = extensibleRecord(1, Name.fromString("someName"), zio.Chunk(var1, var2))
         val expected =
           """["extensible_record",1,["some","name"],[[["first"],["variable",123,["f"]]],[["second"],["variable",345,["g"]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.TupleCase") {
         val var1     = variable[Int](123, "f")
         val var2     = variable[Int](345, "g")
         val actual   = tuple(1, var1, var2)
         val expected = """["tuple",1,[["variable",123,["f"]],["variable",345,["g"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.ReferenceCase") {
         val var1   = variable[Int](123, "f")
@@ -264,7 +265,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = reference(1, FQName.fromString("test:JavaHome:morphir"), zio.Chunk(var1, var2))
         val expected =
           """["reference",1,[[["test"]],[["java","home"]],["morphir"]],[["variable",123,["f"]],["variable",345,["g"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TypeCase.FunctionCase") {
         val var1   = variable[Int](123, "f")
@@ -272,20 +273,20 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = function(1, var1, var2)
         val expected =
           """["function",1,["variable",123,["f"]],["variable",345,["g"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Constructors")(
       test("will encode empty Constructor") {
         val actual   = Constructors[Int](Map.empty)
         val expected = """[]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Constructors with one constructor") {
         val name     = Name.fromString("name")
         val actual   = Constructors[Int](Map((name, zio.Chunk((name, variable[Int](123, "f"))))))
         val expected = """[[["name"],[[["name"],["variable",123,["f"]]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Constructors") {
         val name1 = Name.fromString("name1")
@@ -300,7 +301,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         )
         val expected =
           """[[["name","1"],[[["name","1"],["variable",123,["f"]]],[["name","2"],["variable",345,["g"]]]]],[["name","2"],[[["name","3"],["variable",678,["h"]]],[["name","4"],["variable",789,["i"]]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("org.finos.morphir.ir.Type.Definition")(
@@ -309,7 +310,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val name2    = Name.fromString("name2")
         val actual   = TypeDefinition.TypeAlias[Int](zio.Chunk(name1, name2), variable[Int](345, "g"))
         val expected = """["type_alias_definition",[["name","1"],["name","2"]],["variable",345,["g"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode CustomType") {
         val name1 = Name.fromString("name1")
@@ -328,7 +329,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = TypeDefinition.CustomType[Int](zio.Chunk(name1, name2), ctors)
         val expected =
           """["custom_type_definition",[["name","1"],["name","2"]],["public",[[["name","1"],[[["name","1"],["variable",123,["f"]]],[["name","2"],["variable",345,["g"]]]]],[["name","2"],[[["name","3"],["variable",678,["h"]]],[["name","4"],["variable",789,["i"]]]]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("org.finos.morphir.ir.Type.Specification")(
@@ -338,7 +339,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual =
           TypeSpecification.TypeAliasSpecification[Int](zio.Chunk(name1, name2), variable[Int](345, "g"))
         val expected = """["type_alias_specification",[["name","1"],["name","2"]],["variable",345,["g"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode CustomTypeSpecification") {
         val name1 = Name.fromString("name1")
@@ -354,7 +355,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = TypeSpecification.CustomTypeSpecification[Int](zio.Chunk(name1, name2), ctors)
         val expected =
           """["custom_type_specification",[["name","1"],["name","2"]],[[["name","1"],[[["name","1"],["variable",123,["f"]]],[["name","2"],["variable",345,["g"]]]]],[["name","2"],[[["name","3"],["variable",678,["h"]]],[["name","4"],["variable",789,["i"]]]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode OpaqueTypeSpecification") {
         val name1  = Name.fromString("name1")
@@ -362,14 +363,14 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = TypeSpecification.OpaqueTypeSpecification(zio.Chunk(name1, name2))
         val expected =
           """["opaque_type_specification",[["name","1"],["name","2"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Pattern")(
       test("will encode AsPattern") {
         val actual   = Pattern.AsPattern[Int](1, Pattern.WildcardPattern[Int](1), Name.fromString("wildCard"))
         val expected = """["as_pattern",1,["wildcard_pattern",1],["wild","card"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode ConstructorPattern") {
         val patterns: zio.Chunk[Pattern[Int]] = zio.Chunk(
@@ -380,22 +381,22 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = Pattern.ConstructorPattern[Int](1, FQName.fromString("test:JavaHome:morphir"), patterns)
         val expected =
           """["constructor_pattern",1,[[["test"]],[["java","home"]],["morphir"]],[["wildcard_pattern",1],["empty_list_pattern",2],["as_pattern",1,["wildcard_pattern",1],["wild","card"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode EmptyListPattern") {
         val actual   = Pattern.EmptyListPattern[Int](1)
         val expected = """["empty_list_pattern",1]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode LiteralPattern") {
         val actual   = Pattern.LiteralPattern[Int](1, StringLiteral("hello"))
         val expected = """["literal_pattern",1,["string_literal","hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode HeadTailPattern") {
         val actual = Pattern.HeadTailPattern[Int](1, Pattern.WildcardPattern[Int](1), Pattern.EmptyListPattern[Int](2))
         val expected = """["head_tail_pattern",1,["wildcard_pattern",1],["empty_list_pattern",2]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode TuplePattern") {
         val patterns: zio.Chunk[Pattern[Int]] = zio.Chunk(
@@ -406,17 +407,17 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = Pattern.TuplePattern[Int](1, patterns)
         val expected =
           """["tuple_pattern",1,[["wildcard_pattern",1],["unit_pattern",2],["as_pattern",1,["wildcard_pattern",1],["wild","card"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode UnitPattern") {
         val actual   = Pattern.UnitPattern[Int](1)
         val expected = """["unit_pattern",1]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode WildcardPattern") {
         val actual   = Pattern.WildcardPattern[Int](1)
         val expected = """["wildcard_pattern",1]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ValueDefinition")(
@@ -429,7 +430,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
           ValueDefinition[Int, Int](inputParams, variable[Int](345, "g"), Value.Unit(1))
         val expected =
           """{"inputTypes":[[["name","1"],1,["variable",345,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",345,["g"]],"body":["unit",1]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ValueSpecification")(
@@ -441,7 +442,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = ValueSpecification[Int](inputs, variable[Int](111, "f"))
         val expected =
           """{"inputs":[[["name","1"],["variable",345,["g"]]],[["name","2"],["variable",678,["h"]]]],"outputs":["variable",111,["f"]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ModuleSpecification")(
@@ -463,7 +464,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = ModuleSpecification[Int](typeMap, valueMap)
         val expected =
           """{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["variable",345,["g"]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["variable",345,["g"]]],[["name","2"],["variable",678,["h"]]]],"outputs":["variable",111,["f"]]}]]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("ModuleDefinition")(
@@ -493,7 +494,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = ModuleDefinition[Int, Int](typeMap, valueMap)
         val expected =
           """{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["variable",345,["g"]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],1,["variable",345,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",345,["g"]],"body":["constructor",1,[[["test"]],[["java","home"]],["morphir"]]]}]]]]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("PackageSpecification")(
@@ -518,7 +519,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual  = PackageSpecification[Int](Map(modName1 -> modSpec, modName2 -> modSpec))
         val expected =
           """{"modules":[{"name":[[["org"]],["src"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["variable",345,["g"]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["variable",345,["g"]]],[["name","2"],["variable",678,["h"]]]],"outputs":["variable",111,["f"]]}]]]}},{"name":[[["org"]],["test"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["variable",345,["g"]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["variable",345,["g"]]],[["name","2"],["variable",678,["h"]]]],"outputs":["variable",111,["f"]]}]]]}}]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("PackageDefinition")(
@@ -559,7 +560,8 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
 
         val expected =
           """{"modules":[{"name":[[["org"]],["src"]],"def":["public",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["variable",345,["g"]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],1,["variable",345,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",345,["g"]],"body":["constructor",1,[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]},{"name":[[["org"]],["test"]],"def":["public",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["variable",345,["g"]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],1,["variable",345,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",345,["g"]],"body":["constructor",1,[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]}]}"""
-        assertTrue(actual.toJson == expected)
+
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Value")(
@@ -567,46 +569,46 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val unitCase = Value.Unit(6)
         val actual   = Value.Apply[Unit, Int](3, unitCase, unitCase)
         val expected = """["apply",3,["unit",6],["unit",6]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Constructor") {
         val name     = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val actual   = Value.Constructor(3, name)
         val expected = """["constructor",3,[[["com"],["example"]],[["java","home"]],["morphir"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Destructure") {
         val pattern  = Pattern.WildcardPattern[Int](1)
         val unitCase = Value.Unit(6)
         val actual   = Value.Destructure[Unit, Int](3, pattern, unitCase, unitCase)
         val expected = """["destructure",3,["wildcard_pattern",1],["unit",6],["unit",6]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Field") {
         val name     = Name("Hello")
         val unitCase = Value.Unit(6)
         val actual   = Value.Field[Unit, Int](3, unitCase, name)
         val expected = """["field",3,["unit",6],["hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - FieldFunction") {
         val actual   = Value.FieldFunction(3, Name("Hello"))
         val expected = """["field_function",3,["hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - IfThenElse") {
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val unitCase          = Value.Unit(6)
         val actual            = Value.IfThenElse[Unit, Int](3, unitCase, fieldFunctionCase, unitCase)
         val expected          = """["if_then_else",3,["unit",6],["field_function",3,["hello"]],["unit",6]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Lambda") {
         val pattern           = Pattern.WildcardPattern[Int](1)
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val actual            = Value.Lambda[Unit, Int](3, pattern, fieldFunctionCase)
         val expected          = """["lambda",3,["wildcard_pattern",1],["field_function",3,["hello"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - LetDefinition") {
         val inputParams = zio.Chunk(
@@ -621,7 +623,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = Value.LetDefinition(3, Name("Hi"), valueDefinition, fieldFunctionCase)
         val expected =
           """["let_definition",3,["hi"],{"inputTypes":[[["name","1"],1,["variable",444,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",345,["g"]],"body":["literal",3,["bool_literal",true]]},["field_function",3,["hello"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       // test("will encode and decode Value - LetDefinition - with Any") {
       //   object Refs {
@@ -713,20 +715,20 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual            = Value.LetRecursion(3, valueDefinitions, fieldFunctionCase)
         val expected =
           """["let_recursion",3,[[["key","1"],{"inputTypes":[[["name","1"],1,["variable",444,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",333,["x"]],"body":["literal",3,["bool_literal",true]]}],[["key","2"],{"inputTypes":[[["name","1"],1,["variable",444,["g"]]],[["name","2"],2,["variable",678,["h"]]]],"outputType":["variable",333,["x"]],"body":["literal",3,["bool_literal",true]]}]],["field_function",3,["hello"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - ListCase") {
         val unitCase          = Value.Unit(6)
         val fieldFunctionCase = Value.FieldFunction(3, Name("Hello"))
         val actual            = Value.List(3, zio.Chunk[Value[Int, Int]](unitCase, fieldFunctionCase))
         val expected          = """["list",3,[["unit",6],["field_function",3,["hello"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Literal") {
         val literal  = BoolLiteral(true)
         val actual   = Value.Literal(3, literal)
         val expected = """["literal",3,["bool_literal",true]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - PatternMatch") {
         val unitCase          = Value.Unit(6)
@@ -734,7 +736,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val patterns          = zio.Chunk((Pattern.WildcardPattern[Int](12), fieldFunctionCase))
         val actual            = Value.PatternMatch[Unit, Int](3, unitCase, patterns)
         val expected = """["pattern_match",3,["unit",6],[[["wildcard_pattern",12],["field_function",3,["hello"]]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Record") {
         val unitCase          = Value.Unit(6)
@@ -742,13 +744,13 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val fields            = zio.Chunk((Name("hello"), fieldFunctionCase), (Name("there"), unitCase))
         val actual            = Value.Record[Unit, Int](3, fields)
         val expected          = """["record",3,[[["hello"],["field_function",3,["hello"]]],[["there"],["unit",6]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Reference") {
         val name     = FQName.fromString("Com.Example;JavaHome;morphir", ";")
         val actual   = Value.Reference(3, name)
         val expected = """["reference",3,[[["com"],["example"]],[["java","home"]],["morphir"]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Tuple") {
         val unitCase          = Value.Unit(6)
@@ -756,7 +758,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val elements          = zio.Chunk(unitCase, fieldFunctionCase)
         val actual            = Value.Tuple[Unit, Int](3, elements)
         val expected          = """["tuple",3,[["unit",6],["field_function",3,["hello"]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - UpdateRecord") {
         val unitCase          = Value.Unit(6)
@@ -765,17 +767,17 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual            = Value.UpdateRecord[Unit, Int](3, unitCase, fields)
         val expected =
           """["update_record",3,["unit",6],[[["hello"],["field_function",3,["hello"]]],[["there"],["unit",6]]]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Unit") {
         val actual   = Value.Unit(6)
         val expected = """["unit",6]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("will encode Value - Variable") {
         val actual   = Value.Variable(3, Name("hello"))
         val expected = """["variable",3,["hello"]]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("Distribution")(
@@ -832,7 +834,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = Library(packageName, dependencies, packageDef)
         val expected =
           """["library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[{"name":[[["org"]],["src"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}},{"name":[[["org"]],["test"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}}]}]],{"modules":[{"name":[[["org"]],["src"]],"def":["public",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]},{"name":[[["org"]],["test"]],"def":["private",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]}]}]"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     ),
     suite("MorphirIRFile")(
@@ -889,7 +891,7 @@ object MorphirJsonEncodingSpecV1 extends ZIOSpecDefault {
         val actual = MorphirIRFile(MorphirIRVersion.V1_0, Library(packageName, dependencies, packageDef))
         val expected =
           """{"formatVersion":1,"distribution":["library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[{"name":[[["org"]],["src"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}},{"name":[[["org"]],["test"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}}]}]],{"modules":[{"name":[[["org"]],["src"]],"def":["public",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]},{"name":[[["org"]],["test"]],"def":["private",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]}]}]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       }
     )
   )

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonMorphirIRFileSpec.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/MorphirJsonMorphirIRFileSpec.scala
@@ -22,6 +22,7 @@ import org.finos.morphir.ir.Type.{Definition => TypeDefinition, Specification =>
 import org.finos.morphir.ir.Value.{Definition => ValueDefinition, Pattern, Specification => ValueSpecification, Value}
 import org.finos.morphir.ir._
 import org.finos.morphir.ir.json.MorphirJsonFileSupport._
+import org.finos.morphir.ir.json.util.CustomAssert._
 import zio.test.*
 
 object MorphirJsonMorphirIRFileSpec extends ZIOSpecDefault {
@@ -31,15 +32,13 @@ object MorphirJsonMorphirIRFileSpec extends ZIOSpecDefault {
         val actual = MorphirIRFile(MorphirIRVersion.V1_0, library)
         val expected =
           """{"formatVersion":1,"distribution":["library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[{"name":[["org"],["src"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}},{"name":[["org"],["test"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}}]}]],{"modules":[{"name":[["org"],["src"]],"def":["public",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]},{"name":[[["org"]],["test"]],"def":["private",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]}]}]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("decoding") {
         val expected = MorphirIRFile(MorphirIRVersion.V1_0, library)
         val actual =
           """{"formatVersion":1,"distribution":["library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[{"name":[["org"],["src"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}},{"name":[["org"],["test"]],"spec":{"types":[[["name"],["typeDoc1",["type_alias_specification",[["name","1"],["name","2"]],["unit",[]]]]]],"values":[[["name"],["valueDoc1",{"inputs":[[["name","1"],["unit",[]]],[["name","2"],["unit",[]]]],"outputs":["unit",[]]}]]]}}]}]],{"modules":[{"name":[["org"],["src"]],"def":["public",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]},{"name":[[["org"]],["test"]],"def":["private",{"types":[[["name"],["private",["typeDoc1",["type_alias_definition",[["name","1"],["name","2"]],["unit",[]]]]]]],"values":[[["name"],["private",["valueDoc1",{"inputTypes":[[["name","1"],["unit",[]],["unit",[]]],[["name","2"],["unit",[]],["unit",[]]]],"outputType":["unit",[]],"body":["constructor",["unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}]]]]}]}]}]}"""
-        assertTrue(
-          actual.fromJson[MorphirIRFile] == Right(expected)
-        )
+        assert(actual.fromJson[MorphirIRFile])(objectEqualTo(Right(expected)))
       }
     ),
     suite("MorphirIRFile Version 2")(
@@ -47,15 +46,13 @@ object MorphirJsonMorphirIRFileSpec extends ZIOSpecDefault {
         val actual = MorphirIRFile(MorphirIRVersion.V2_0, library)
         val expected =
           """{"formatVersion":2,"distribution":["Library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[[[["org"],["src"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}],[[["org"],["test"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}]]}]],{"modules":[[[["org"],["src"]],{"access":"Public","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}],[[["org"],["test"]],{"access":"Private","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}]]}]}"""
-        assertTrue(actual.toJson == expected)
+        assert(actual.toJson)(stringEqualTo(expected))
       },
       test("decoding") {
         val expected = MorphirIRFile(MorphirIRVersion.V2_0, library)
         val actual =
           """{"formatVersion":2,"distribution":["Library",[["morphir"],["s","d","k"]],[[[["org"],["finos"],["morphir"],["ir"]],{"modules":[[[["org"],["src"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}],[[["org"],["test"]],{"types":[[["name"],{"doc":"typeDoc1","value":["TypeAliasSpecification",[["name","1"],["name","2"]],["Unit",[]]]}]],"values":[[["name"],{"doc":"valueDoc1","value":{"inputs":[[["name","1"],["Unit",[]]],[["name","2"],["Unit",[]]]],"outputs":["Unit",[]]}}]]}]]}]],{"modules":[[[["org"],["src"]],{"access":"Public","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}],[[["org"],["test"]],{"access":"Private","value":{"types":[[["name"],{"access":"Private","value":{"doc":"typeDoc1","value":["TypeAliasDefinition",[["name","1"],["name","2"]],["Unit",[]]]}}]],"values":[[["name"],{"access":"Private","value":{"doc":"valueDoc1","value":{"inputTypes":[[["name","1"],["Unit",[]],["Unit",[]]],[["name","2"],["Unit",[]],["Unit",[]]]],"outputType":["Unit",[]],"body":["constructor",["Unit",[]],[[["test"]],[["java","home"]],["morphir"]]]}}}]]}}]]}]}"""
-        assertTrue(
-          actual.fromJson[MorphirIRFile] == Right(expected)
-        )
+        assert(actual.fromJson[MorphirIRFile])(objectEqualTo(Right(expected)))
       }
     )
   )

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/util/Compare.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/util/Compare.scala
@@ -1,0 +1,152 @@
+package org.finos.morphir.ir.json.util
+
+import scala.collection.immutable.ListMap
+import scala.reflect.ClassTag
+import scala.collection.immutable
+
+object Compare {
+  sealed trait Diff
+  object Diff {
+    case class MissingRight(leftValue: Any) extends Diff
+    case class MissingLeft(rightValue: Any) extends Diff
+
+    case class Object(typename: String, fields: ListMap[String, Diff])   extends Diff
+    case class Sequence(typename: String, fields: ListMap[String, Diff]) extends Diff
+
+    case class Leaf(typename: String, a: Any, b: Any)                      extends Diff
+    case class Leaf2(typenameA: String, typenameB: String, a: Any, b: Any) extends Diff
+
+    case class Set(typename: String, onlyLeft: immutable.Set[Any], onlyRight: immutable.Set[Any]) extends Diff
+
+    implicit class WithFieldExt(diff: Option[Diff]) {
+      def withField(field: String) =
+        diff.map(v => (field, v))
+    }
+
+    object Leaf {
+      def of[T](a: T, b: T)(implicit ct: ClassTag[T]): Option[Diff] =
+        if (a == b)
+          None
+        else
+          Some(Leaf(className(ct.runtimeClass), a, b))
+      def ofClass(aCls: Class[_], bCls: Class[_])(a: Any, b: Any): Option[Diff] =
+        if (aCls != bCls && a != b)
+          Some(Leaf2(className(aCls), className(bCls), a, b))
+        else if (aCls == bCls && a != b)
+          Some(Leaf(className(aCls), a, b))
+        else
+          None
+    }
+  }
+
+  def apply(a: Any, b: Any): Option[Diff] = generic(a, b)
+  private def generic(aValue: Any, bValue: Any): Option[Diff] =
+    (aValue, bValue) match {
+      case _ if (aValue == bValue) => None
+      // Needs specialized by-content comparator for sets
+      case (a: Set[_], b: Set[_])           => set(a, b)
+      case (a: Iterable[_], b: Iterable[_]) => iterable(a, b)
+      case (a: Int, b: Int)                 => Diff.Leaf.of(a, b)
+      case (a: Short, b: Short)             => Diff.Leaf.of(a, b)
+      case (a: Boolean, b: Boolean)         => Diff.Leaf.of(a, b)
+      case (a: Double, b: Double)           => Diff.Leaf.of(a, b)
+      case (a: Float, b: Float)             => Diff.Leaf.of(a, b)
+      case (a: Byte, b: Byte)               => Diff.Leaf.of(a, b)
+      case (a: Char, b: Char)               => Diff.Leaf.of(a, b)
+      case (a: Product, b: Product)         => product(a, b)
+      case (a: AnyRef, b: AnyRef)           => Diff.Leaf.ofClass(a.getClass, b.getClass)(a, b)
+    }
+
+  private def set(ai: Set[_], bi: Set[_]): Option[Diff] = {
+    val a     = ai.asInstanceOf[Set[Any]]
+    val b     = bi.asInstanceOf[Set[Any]]
+    val onlyA = a.removedAll(b)
+    val onlyB = b.removedAll(a)
+    if (onlyA.isEmpty && onlyB.isEmpty)
+      None
+    else
+      Some(Diff.Set("Set", onlyA, onlyB))
+  }
+
+  private def iterable(ai: Iterable[_], bi: Iterable[_]): Option[Diff] = {
+    val fields =
+      ai.map(Option(_))
+        .zipAll(bi.map(Option(_)), None, None)
+        .zipWithIndex
+        .map {
+          // TODO Compare(0, a, b, c) to Compare(a, b, c) should return diff 0
+          case ((Some(a), Some(b)), index) => generic(a, b).withField(index.toString)
+          case ((None, Some(a)), index)    => Some(Diff.MissingLeft(a)).withField(index.toString)
+          case ((Some(a), None), index)    => Some(Diff.MissingRight(a)).withField(index.toString)
+          case _                           => None
+        }
+        .collect { case Some(v) => v }
+        .toList
+    if (fields.isEmpty)
+      None
+    else
+      Some(Diff.Sequence(className(ai.getClass), ListMap.from(fields)))
+  }
+
+  private def trySimpleName(cls: Class[_]) =
+    try
+      cls.getSimpleName
+    catch {
+      case e: Throwable => cls.getName
+    }
+
+  private def className(cls: Class[_]) = {
+    val ancestry  = new Ancestry(cls)
+    val matchSeq  = new MatchAncestry("scala.collection.Seq")
+    val matchList = new MatchAncestry("scala.collection.List")
+    ancestry match {
+      case matchSeq(listName)  => listName
+      case matchList(listName) => listName
+      case other               => trySimpleName(other.cls)
+    }
+  }
+
+  private def product(a: Product, b: Product): Option[Diff] =
+    if (a.getClass != b.getClass) Diff.Leaf.ofClass(a.getClass, b.getClass)(a, b)
+    else {
+      val clsName = className(a.getClass)
+      val names   = a.productElementNames.toList
+      val as      = a.productIterator.toList
+      val bs      = b.productIterator.toList
+      if (names.length != as.length || as.length != bs.length)
+        throw new RuntimeException(
+          s"""Different element lengths found:
+             |========== Names =========
+             |${names.zipWithIndex.map { case (v, i) => s"$i - $v" }.mkString("\n")}
+             |========== AS ========
+             |${as.zipWithIndex.map { case (v, i) => s"$i - $v" }.mkString("\n")}
+             |========== BS ========
+             |${bs.zipWithIndex.map { case (v, i) => s"$i - $v" }.mkString("\n")}""".stripMargin
+        )
+      if (as == bs) None
+      else {
+        val fields =
+          ListMap.from(
+            names
+              .zip(as)
+              .zip(bs)
+              .map { case ((name, a), b) => generic(a, b).withField(name) }
+              .collect { case Some((field, value)) => (field, value) }
+          )
+        Some(Diff.Object(clsName, fields))
+      }
+    }
+
+  class Ancestry(val cls: Class[_]) {
+    def ancestry(cls: Class[_]): List[Class[_]] = {
+      val superCls = cls.getSuperclass
+      if (superCls != null) cls +: ancestry(superCls)
+      else cls :: Nil
+    }
+    val interfaces = ancestry(cls).flatMap(cls => cls.getInterfaces)
+  }
+  class MatchAncestry(name: String) {
+    def unapply(ancestry: Ancestry): Option[String] =
+      ancestry.interfaces.find(_.getName.matches(name)).map(trySimpleName(_))
+  }
+}

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/util/CustomAssert.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/util/CustomAssert.scala
@@ -1,0 +1,87 @@
+package org.finos.morphir.ir.json.util
+
+import zio.test.*
+import zio.test.Assertion.equalTo
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import com.fasterxml.jackson.core.util.DefaultIndenter
+
+object CustomAssert {
+  def stringEqualTo(thatRaw: String): Assertion[String] =
+    Assertion[String] {
+      import zio.test.diff.Diff
+      import zio.test.{ErrorMessage => M}
+      import zio.test.diff.{Diff, DiffResult}
+      import zio.internal.ansi._
+      import scala.{Console => SConsole}
+      object ConsoleUtils {
+        def underlined(s: String): String =
+          SConsole.UNDERLINED + s + SConsole.RESET
+      }
+      TestArrow
+        .make[String, Boolean] { aRaw =>
+          val result = aRaw == thatRaw
+          TestTrace.boolean(result) {
+            val printer  = new DefaultPrettyPrinter();
+            val indenter = new DefaultIndenter("", "")
+            printer.indentArraysWith(indenter)
+            val mapper = new ObjectMapper()
+            val writer = mapper.writer(printer)
+
+            val (that, a) =
+              (for {
+                thatFormatted <- scala.util.Try(mapper.readTree(thatRaw))
+                aFormatted    <- scala.util.Try(mapper.readTree(aRaw))
+              } yield (writer.writeValueAsString(thatFormatted), writer.writeValueAsString(aFormatted)))
+                .getOrElse((thatRaw, aRaw))
+
+            val diffResult = Diff.stringDiff.diff(that, a)
+            diffResult match {
+              case DiffResult.Different(_, _, None) =>
+                M.pretty(a) + M.equals + M.pretty(that)
+              case diffResult =>
+                M.choice("There was no difference", "There was a difference") ++
+                  M.custom(
+                    ConsoleUtils.underlined(
+                      "Diff"
+                    ) + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+obtained".faint
+                  ) ++
+                  M.custom(scala.Console.RESET + diffResult.render)
+
+              // Can also get a pretty printer Expected/Actual output but not doing that for
+              // now because it is too verbose
+              // ++
+              // M.custom(ConsoleUtils.underlined("Expected") + "\n") ++
+              // M.text(a) ++
+              // M.custom(ConsoleUtils.underlined("Actual") + "\n") ++
+              // M.text(that)
+            }
+          }
+        }
+    }
+
+  def objectEqualTo[T](that: T): Assertion[T] =
+    Assertion[T] {
+      import zio.test.diff.Diff
+      import zio.test.{ErrorMessage => M}
+      import zio.test.diff.{Diff, DiffResult}
+      import zio.internal.ansi._
+      import scala.{Console => SConsole}
+      object ConsoleUtils {
+        def underlined(s: String): String =
+          SConsole.UNDERLINED + s + SConsole.RESET
+      }
+      TestArrow
+        .make[T, Boolean] { a =>
+          val result = a == that
+          TestTrace.boolean(result) {
+            val compare = Compare(a, that)
+            val printedDiff =
+              compare.map(PrintDiff(_).toString()).getOrElse("<No Diff: Contents Identical>")
+
+            M.text(printedDiff)
+          }
+        }
+    }
+}

--- a/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/util/PrintDiff.scala
+++ b/morphir/toolkit/codec/zio/json/test/src/org/finos/morphir/ir/json/util/PrintDiff.scala
@@ -1,0 +1,197 @@
+package org.finos.morphir.ir.json.util
+
+object PrintDiff {
+  def apply(value: Compare.Diff) = new PrintDiff().apply(value)
+}
+
+private class PrintDiff(val defaultWidth: Int = 150) extends pprint.Walker {
+  import fansi.Str
+  import pprint.{Renderer, Tree, Truncated}
+  import java.util.function.UnaryOperator
+  import pprint.Tree.Apply
+  import pprint.Tree.KeyValue
+  import pprint.Tree.Lazy
+  import pprint.Tree.Infix
+
+  // Show field names e.g.
+  // Property(ir = Ident(name = "inst"), name = "currentDate") vs
+  // Property(Ident("inst"), "currentDate")
+  val showFieldNames                = false
+  val escapeUnicode                 = false
+  val defaultHeight: Int            = Integer.MAX_VALUE
+  val defaultIndent: Int            = 2
+  val colorLiteral: fansi.Attrs     = fansi.Color.Green
+  val colorApplyPrefix: fansi.Attrs = fansi.Color.Yellow
+  var verbose: Boolean              = false
+
+  override def additionalHandlers: PartialFunction[Any, Tree] = PartialFunction.empty
+
+  def apply(x: Any, verbose: Boolean = false): fansi.Str = {
+    this.verbose = verbose
+    val tokenized = this.tokenize(x).toSeq
+    fansi.Str.join(tokenized)
+  }
+
+  def tokenize(x: Any): Iterator[fansi.Str] = {
+    val tree      = this.treeify(x)
+    val renderer  = new Renderer(defaultWidth, colorApplyPrefix, colorLiteral, defaultIndent)
+    val rendered  = renderer.rec(tree, 0, 0).iter
+    val truncated = new Truncated(rendered, defaultWidth, defaultHeight)
+    truncated
+  }
+
+  def treeify(x: Any): Tree = this.treeify(x, escapeUnicode, showFieldNames)
+
+  /**
+   * In the situation where one tree is subtantially larger than another (e.g. 1-line vs 50-lines) it typically does not
+   * make sense to show the larger tree in its entirely because the difference is at the 'tips' of the trees. In the
+   * case of MorphirJsonDecoding specs showing the larger tree in its entirety would introduce such a large amount of
+   * noise that the logs became impractical to use.
+   */
+  def truncateSmallerTree(aRaw: Tree, bRaw: Tree) = {
+    // Need to make duplicates to do countMaxDepth because it is destructive because the Tree has mutable iterators
+    val (a, aDup) = duplicateTree(aRaw)
+    val (b, bDup) = duplicateTree(bRaw)
+
+    val (smallLabel, smallTree, smallDepth) :: (largeLabel, largeTree, largeDepth) :: Nil =
+      List(("a", a, countMaxDepth(aDup)), ("b", b, countMaxDepth(bDup))).sortBy(_._3)
+
+    // Activate this logic if one tree is 5x as large as the other or bigger
+    val largeTreeTruncated =
+      if (largeDepth >= smallDepth * 5) {
+        truncateDepth(largeTree, smallDepth * 5)
+      } else {
+        largeTree
+      }
+
+    // put them back into a/b order by sort by the labels which will be either "a", or "b"
+    val (aLabel, aOut) :: (bLabel, bOut) :: Nil =
+      List((smallLabel, smallTree), (largeLabel, largeTreeTruncated)).sortBy(_._1)
+
+    (aOut, bOut)
+  }
+
+  def truncateDepth(tree: Tree, truncateDepth: Int) = {
+    def truncateDepthRec(tree: Tree, currDepth: Int): Tree =
+      if (currDepth >= truncateDepth)
+        Tree.Literal("...")
+      else
+        tree match {
+          case Apply(prefix, body) => Apply(prefix, body.toList.map(truncateDepthRec(_, currDepth + 1)).iterator)
+          case l @ Lazy(_)         => l // don't do anything ro lazy values
+          case Infix(lhs, op, rhs) =>
+            Infix(truncateDepthRec(lhs, currDepth + 1), op, truncateDepthRec(rhs, currDepth + 1))
+          case l @ Tree.Literal(_)  => l
+          case KeyValue(key, value) => KeyValue(key, truncateDepthRec(value, currDepth + 1))
+        }
+
+    truncateDepthRec(tree, 0)
+  }
+
+  def duplicateTree(tree: Tree): (Tree, Tree) =
+    tree match {
+      case Apply(prefix, body) =>
+        val (aBody, bBody) = body.toList.map(duplicateTree(_)).unzip
+        (Apply(prefix, aBody.iterator), Apply(prefix, bBody.iterator))
+
+      case KeyValue(key, value) =>
+        val (value1, value2) = duplicateTree(value)
+        (KeyValue(key, value1), KeyValue(key, value2))
+
+      case l @ Lazy(_) => (l, l)
+
+      case Infix(lhs, op, rhs) =>
+        val (lhs1, lhs2) = duplicateTree(lhs)
+        val (rhs1, rhs2) = duplicateTree(rhs)
+        (Infix(lhs1, op, rhs1), Infix(lhs2, op, rhs2))
+
+      case l @ Tree.Literal(_) => (l, l)
+    }
+
+    // IMPORTANT - This function is actually destructive since it will make the Tree.Apply.body's iterator go to the end,
+  // make sure to copy the tree before doing it
+  def countMaxDepth(tree: Tree, currDepth: Int = 0): Int =
+    tree match {
+      case Apply(prefix, body)  => body.toList.map(countMaxDepth(_, currDepth + 1)).maxOption.getOrElse(0)
+      case KeyValue(key, value) => countMaxDepth(value, currDepth + 1)
+      case Lazy(body0)          => currDepth // don't know what to do about lazy trees for now
+      case Infix(lhs, op, rhs)  => Math.max(countMaxDepth(lhs, currDepth + 1), countMaxDepth(rhs, currDepth + 1))
+      case Tree.Literal(body)   => currDepth
+    }
+
+  override def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean): Tree = x match {
+    case l: Compare.Diff.Leaf =>
+      val leftRaw  = treeify(l.a, escapeUnicode, showFieldNames)
+      val rightRaw = treeify(l.b, escapeUnicode, showFieldNames)
+      // after invoking the below function cannot use leftRaw, rightRaw anymore because Tree.Apply uses iterators
+      val (a, b) = truncateSmallerTree(leftRaw, rightRaw)
+      Tree.Apply(
+        "Diff",
+        List(
+          Tree.KeyValue("left", a),
+          Tree.KeyValue("right", b)
+        ).iterator
+      )
+
+    case l: Compare.Diff.Leaf2 =>
+      val leftRaw  = treeify(l.a, escapeUnicode, showFieldNames)
+      val rightRaw = treeify(l.b, escapeUnicode, showFieldNames)
+      // after invoking the below function cannot use leftRaw, rightRaw anymore because Tree.Apply uses iterators
+      val (a, b) = truncateSmallerTree(leftRaw, rightRaw)
+      Tree.Apply(
+        "Diff",
+        List(
+          Tree.KeyValue("left", a),
+          Tree.KeyValue("right", b)
+        ).iterator
+      )
+
+    case s: Compare.Diff.Set =>
+      Tree.Apply(
+        s.typename,
+        List(
+          Tree.Apply("onlyLeft", s.onlyLeft.toList.map(treeify(_, escapeUnicode, showFieldNames)).iterator),
+          Tree.Apply("onlyRight", s.onlyRight.toList.map(treeify(_, escapeUnicode, showFieldNames)).iterator)
+        ).iterator
+      )
+
+    case m: Compare.Diff.MissingLeft =>
+      Tree.Apply(
+        "Diff",
+        List(
+          Tree.KeyValue("left", Tree.Literal("Missing")),
+          Tree.KeyValue("right", treeify(m.rightValue, escapeUnicode, showFieldNames))
+        ).iterator
+      )
+
+    case m: Compare.Diff.MissingRight =>
+      Tree.Apply(
+        "Diff",
+        List(
+          Tree.KeyValue("left", treeify(m.leftValue, escapeUnicode, showFieldNames)),
+          Tree.KeyValue("right", Tree.Literal("Missing"))
+        ).iterator
+      )
+
+    case s: Compare.Diff.Sequence =>
+      Tree.Apply(
+        s.typename,
+        s.fields.toList
+          .sortBy(_._1)
+          .map { case (key, diff) =>
+            Tree.KeyValue(key, treeify(diff, escapeUnicode, showFieldNames))
+          }
+          .iterator
+      )
+
+    case o: Compare.Diff.Object =>
+      Tree.Apply(
+        o.typename,
+        o.fields.map { case (name, value) =>
+          Tree.KeyValue(name, treeify(value, escapeUnicode, showFieldNames))
+        }.iterator
+      )
+
+    case other => super.treeify(other, escapeUnicode, showFieldNames)
+  }
+}


### PR DESCRIPTION
* Use deblockt diff utility to summarize diffs
* Use command line diff util (with some edits to be able to make apply-able patch files) via VSCode [Git Patch Utility](https://marketplace.visualstudio.com/items?itemName=maketes.git-patch-utility) and viewable via [Diff Viewer](https://marketplace.visualstudio.com/items?itemName=caponetto.vscode-diff-viewer).
* Custom zio-test functions for comparison of json strings and deep-nested case classes